### PR TITLE
V0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 0.0.6
 * `Binary Motion`:
-  * Added new attribute Writes **last_motion** that shows time when the last motion has occured
+  * Changed default SCAN_INTERVAL to 3 seconds to optimize Motion Detection
 * `Camera`:
   * Added new service `camera.unifiprotect_save_thumbnail`. When calling this services the Thumbnail of the last recorded motion will be saved to disk, and could then be used in an automation, to send to a phone via the `notify` platform. Requires `entity_id` and `filename` as attributes.
 * `Core Module`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
 ## Version 0.0.6
-* `Binary Motion`:
+* `binary_sensor_`:
   * Changed default SCAN_INTERVAL to 3 seconds to optimize Motion Detection
-* `Camera`:
+* `camera`:
   * Added new service `camera.unifiprotect_save_thumbnail`. When calling this services the Thumbnail of the last recorded motion will be saved to disk, and could then be used in an automation, to send to a phone via the `notify` platform. Requires `entity_id` and `filename` as attributes.
+* `sensor`:
+  * Added new attribute `camera_type` to the sensor. Showing what type of Unfi Camera is attached to this sensor
 * `Core Module`
   * changed size of the thumbnail image when being created.
   * fixed error when no *Last Motion* record exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## Version 0.0.6
-* Added 2 new Attributes to the `Binary Motion` Sensors.
-  * **thumbnail** - contains an id for the latest thumbnail image created for an event. Can be used in combination with a new Camera Services that is being worked on
-  * **last_motion** - Writes the time when the last motion has occured
+* `Binary Motion`:
+  * Added new attribute Writes **last_motion** that shows time when the last motion has occured
+* `Camera`:
+  * Added new service `camera.unifiprotect_save_thumbnail`. When calling this services the Thumbnail of the last recorded motion will be saved to disk, and could then be used in an automation, to send to a phone via the `notify` platform. Requires `entity_id` and `filename` as attributes.
 * `Core Module`
   * changed size of the thumbnail image when being created.
-  * cleaned up the code, removing obsolete parts
+  * Fixed error when no *Last Motion* record exist
+  * cleaned up the code, removing obsolete parts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Version 0.0.6
+* Added 2 new Attributes to the `Binary Motion` Sensors.
+  * **thumbnail** - contains an id for the latest thumbnail image created for an event. Can be used in combination with a new Camera Services that is being worked on
+  * **last_motion** - Writes the time when the last motion has occured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,6 @@
 * Added 2 new Attributes to the `Binary Motion` Sensors.
   * **thumbnail** - contains an id for the latest thumbnail image created for an event. Can be used in combination with a new Camera Services that is being worked on
   * **last_motion** - Writes the time when the last motion has occured
+* `Core Module`
+  * changed size of the thumbnail image when being created.
+  * cleaned up the code, removing obsolete parts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,5 @@
   * Added new service `camera.unifiprotect_save_thumbnail`. When calling this services the Thumbnail of the last recorded motion will be saved to disk, and could then be used in an automation, to send to a phone via the `notify` platform. Requires `entity_id` and `filename` as attributes.
 * `Core Module`
   * changed size of the thumbnail image when being created.
-  * Fixed error when no *Last Motion* record exist
+  * fixed error when no *Last Motion* record exist
   * cleaned up the code, removing obsolete parts.

--- a/README.md
+++ b/README.md
@@ -66,11 +66,16 @@ camera:
   - platform: unifiprotect
 ```
 
-The Integration supports the standard camera services. Not all have been testet but the following will work:
-1. `camera.disable_motion_detection` - This will disable motion detection on the specified camera
-2. `camera.enable_motion_detection` - This will enable motion detection on the specified camera
-3. `camera.snapshot` - Take a snapshot of the current image on the specified camera
-4. `camera.record` - Record the current stream to a file
+The Integration adds specific *Unifi Protect* services and supports the standard camera services. Not all have been testet but the following are working:
+
+Service | Parameters | Description
+:------------ | :------------ | :-------------
+`camera.disable_motion_detection` | `entity_id` - camera to disable motion on | Disable motion detection on the specified camera
+`camera.enable_motion_detection` | `entity_id` - camera to enable motion on | Enable motion detection on the specified camera
+`camera.snapshot` | `entity_id` - Name of entity to create snapshots from.<br>`filename` - Filename to store snapshot in | Take a snapshot of the current image on the specified camera and stor in a file
+`camera.record` | `entity_id` - camera to record from<br>`filename` - Template of a Filename. Variable is entity_id. Must be mp4.<br>`duration` - (Optional) Target recording length (in seconds).<br>`lookback` - (Optional) Target lookback period (in seconds) to include in addition to duration. Only available if there is currently an active HLS stream. | Record the current stream to a file
+`camera.unifiprotect_save_thumbnail` | `entity_id` - Name of entity to retrieve thumbnail from.<br>`filename` - Filename to store thumbnail in | Get the thumbnail image of the last recording event (If any), from the specified camera
+
 
 **Note:** When using *camera.enable_motion_detection*, Recording in Unfi Protect will be set to *motion*. If you want to have the cameras recording all the time, you have to set that in Unifi Protect App.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ In order to use the Sensors, add the following to your *configuration.yaml* file
 sensor:
   - platform: unifiprotect
 ```
-The sensor can have 3 different values:
+The sensor can have 3 different states:
 1. `never` - There will be no recording on the camera
 2. `motion` - Recording will happen only when motion is detected
 3. `always` - The camera will record everything, and motion events will be logged in Unfi Protect

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Unifi Protect for Home Assistant
-![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/briis/unifiprotect?include_prereleases&style=flat-square) [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/briis/unifiprotect?include_prereleases&style=flat-square) [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
 
 This is a Home Assistant Integration for Ubiquiti's Unifi Protect Surveillance system.
 
@@ -32,7 +32,7 @@ protectnvr.py
 ```
 
 ## HACS Installation
-This Integration is not yet part of the default HACS store, but will be once I am convinced it is stable. But it still supports HACS. Just go to settings in HACS and add `briis/unifiprotect` as a Custom Repository. Use *Integration* as Category.
+This Integration is part of the default HACS store. Search for *unifiprotect* under *Integrations* and install from there.
 
 ## Configuration
 Start by configuring the core platform. No matter which of the entities you activate, this has to be configured. The core platform by itself does nothing else than establish a link the *Unifi Protect NVR*, so by activating this you will not see any entities being created in Home Assistant.

--- a/custom_components/unifiprotect/binary_sensor.py
+++ b/custom_components/unifiprotect/binary_sensor.py
@@ -17,6 +17,9 @@ DEPENDENCIES = ['unifiprotect']
 
 SCAN_INTERVAL = timedelta(seconds=5)
 
+ATTR_THUMBNAIL = "thumbnail"
+ATTR_LAST_MOTION = "last_motion"
+
 # sensor_type [ description, unit, icon ]
 SENSOR_TYPES = {
     'motion': ['Motion', 'motion', 'motionDetected']
@@ -51,6 +54,8 @@ class UfpBinarySensor(BinarySensorDevice):
         self._sensor_type = sensor_type
         self._nvrdata = nvrdata
         self._state = False
+        self._thumbnail = None
+        self._last_motion = None
         self._class = SENSOR_TYPES.get(self._sensor_type)[1]
         self._attr = SENSOR_TYPES.get(self._sensor_type)[2]
         self.remove_timer = None
@@ -73,6 +78,8 @@ class UfpBinarySensor(BinarySensorDevice):
 
         attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
         attrs['brand'] = DEFAULT_BRAND
+        attrs[ATTR_THUMBNAIL] = self._thumbnail
+        attrs[ATTR_LAST_MOTION] = self._last_motion 
         attrs['friendly_name'] = self._name
 
         return attrs
@@ -95,6 +102,8 @@ class UfpBinarySensor(BinarySensorDevice):
                 else:
                     is_motion = False
 
+                self._last_motion = event['start']
+                self._thumbnail = event['thumbnail']
                 break
         self._state = is_motion
 

--- a/custom_components/unifiprotect/binary_sensor.py
+++ b/custom_components/unifiprotect/binary_sensor.py
@@ -59,7 +59,7 @@ class UfpBinarySensor(BinarySensorDevice):
         self._class = SENSOR_TYPES.get(self._sensor_type)[1]
         self._attr = SENSOR_TYPES.get(self._sensor_type)[2]
         self.remove_timer = None
-        _LOGGER.info('UfpBinarySensor: %s created', self._name)
+        _LOGGER.debug('UfpBinarySensor: %s created', self._name)
 
     @property
     def unique_id(self):

--- a/custom_components/unifiprotect/binary_sensor.py
+++ b/custom_components/unifiprotect/binary_sensor.py
@@ -92,7 +92,7 @@ class UfpBinarySensor(BinarySensorDevice):
     def update(self):
         """ Updates Motions State."""
 
-        event_list_sorted = sorted(self._nvrdata.events, key=lambda k: k['start'], reverse=True)        
+        event_list_sorted = sorted(self._nvrdata.motion_events, key=lambda k: k['start'], reverse=True)        
         is_motion = None
 
         for event in event_list_sorted:

--- a/custom_components/unifiprotect/binary_sensor.py
+++ b/custom_components/unifiprotect/binary_sensor.py
@@ -15,10 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ['unifiprotect']
 
-SCAN_INTERVAL = timedelta(seconds=5)
-
-ATTR_THUMBNAIL = "thumbnail"
-ATTR_LAST_MOTION = "last_motion"
+SCAN_INTERVAL = timedelta(seconds=3)
 
 # sensor_type [ description, unit, icon ]
 SENSOR_TYPES = {
@@ -54,8 +51,6 @@ class UfpBinarySensor(BinarySensorDevice):
         self._sensor_type = sensor_type
         self._nvrdata = nvrdata
         self._state = False
-        self._thumbnail = None
-        self._last_motion = None
         self._class = SENSOR_TYPES.get(self._sensor_type)[1]
         self._attr = SENSOR_TYPES.get(self._sensor_type)[2]
         self.remove_timer = None
@@ -78,8 +73,6 @@ class UfpBinarySensor(BinarySensorDevice):
 
         attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
         attrs['brand'] = DEFAULT_BRAND
-        attrs[ATTR_THUMBNAIL] = self._thumbnail
-        attrs[ATTR_LAST_MOTION] = self._last_motion 
         attrs['friendly_name'] = self._name
 
         return attrs

--- a/custom_components/unifiprotect/camera.py
+++ b/custom_components/unifiprotect/camera.py
@@ -118,6 +118,7 @@ class UnifiVideoCamera(Camera):
         
         self._motion_status = 'motion'
         self._isrecording = True
+        _LOGGER.debug("Motion Detection Enabled for Camera: " + self._name)
 
     def disable_motion_detection(self):
         """Disable motion detection in camera."""
@@ -127,6 +128,7 @@ class UnifiVideoCamera(Camera):
         
         self._motion_status = 'never'
         self._isrecording = False
+        _LOGGER.debug("Motion Detection Disabled for Camera: " + self._name)
 
     def camera_image(self):
         """Return bytes of camera image."""

--- a/custom_components/unifiprotect/protectnvr.py
+++ b/custom_components/unifiprotect/protectnvr.py
@@ -258,16 +258,13 @@ class protectRemote(object):
         """ Returns a Thumbnail image of a recording event. """
 
         access_key = self._get_api_access_key()
-        img_uri = "https://" + str(self._host) + ":" + str(self._port) + "/api/thumbnails/" + str(tuid) + "?accessKey=" + access_key + "&h=68&w=121"
+        img_uri = "https://" + str(self._host) + ":" + str(self._port) + "/api/thumbnails/" + str(tuid) + "?accessKey=" + access_key + "&h=240&w=427"
         response = self.req.get(img_uri, verify=self._verify_ssl)
         if response.status_code == 200:
-            # output = open("thumbnail.png","wb")
-            # output.write(response.content)
-            # output.close()
             return response.content
         else:
             print("Error Code: " + response.status_code + " - Error Status: " + response.reason)
-            # return None
+            return None
 
     def get_snapshot_image(self, tuid):
         """ Returns a Snapshot image of a recording event. """
@@ -277,11 +274,8 @@ class protectRemote(object):
         img_uri = "https://" + str(self._host) + ":" + str(self._port) + "/api/cameras/" + str(tuid) + "/snapshot?accessKey=" + access_key + "&ts=" + str(ts)
         response = self.req.get(img_uri, verify=self._verify_ssl)
         if response.status_code == 200:
-            # output = open("snapshot.png","wb")
-            # output.write(response.content)
-            # output.close()
             return response.content
         else:
-            # print("Error Code: " + response.status_code + " - Error Status: " + response.reason)
+            print("Error Code: " + response.status_code + " - Error Status: " + response.reason)
             return None
 

--- a/custom_components/unifiprotect/protectnvr.py
+++ b/custom_components/unifiprotect/protectnvr.py
@@ -50,6 +50,12 @@ class protectRemote(object):
         return self._api_event_list
 
     @property
+    def motion_events(self):
+        """ Returns a JSON formatted list of Events. """
+        self._api_event_list = self._get_motion_events(60)
+        return self._api_event_list
+
+    @property
     def snapshot(self, cuid):
         """Returns Snapshot Image."""
         self._snapshot = self.get_snapshot_image(cuid)
@@ -128,8 +134,8 @@ class protectRemote(object):
             return None
 
     # get Motion Events
-    def _get_motion_events(self):
-        _startTime = datetime.datetime.now() - datetime.timedelta(seconds=10000)
+    def _get_motion_events(self, lookback=86400):
+        _startTime = datetime.datetime.now() - datetime.timedelta(seconds=lookback)
         _endTime = datetime.datetime.now() + datetime.timedelta(seconds=10)
         start_time = int(time.mktime(_startTime.timetuple()))
         end_time = int(time.mktime(_endTime.timetuple()))

--- a/custom_components/unifiprotect/protectnvr.py
+++ b/custom_components/unifiprotect/protectnvr.py
@@ -133,8 +133,8 @@ class protectRemote(object):
             # print("Error Code: " + response.status_code + " - Error Status: " + response.reason)
             return None
 
-    # get Motion Events
     def _get_motion_events(self, lookback=86400):
+        """Load the Event Log and loop through items to find motion events."""
         _startTime = datetime.datetime.now() - datetime.timedelta(seconds=lookback)
         _endTime = datetime.datetime.now() + datetime.timedelta(seconds=10)
         start_time = int(time.mktime(_startTime.timetuple()))

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -54,7 +54,7 @@ class UnifiProtectSensor(Entity):
         self._icon = 'mdi:{}'.format(SENSOR_TYPES.get(self._sensor_type)[2])
         self._state = device['recording_mode']
         self._attr = SENSOR_TYPES.get(self._sensor_type)[3]
-        _LOGGER.info('UnifiProtectSensor: %s created', self._name)
+        _LOGGER.debug('UnifiProtectSensor: %s created', self._name)
 
     @property
     def unique_id(self):

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -18,6 +18,8 @@ DEPENDENCIES = ['unifiprotect']
 
 SCAN_INTERVAL = timedelta(seconds=5)
 
+ATTR_CAMERA_TYPE = 'camera_type'
+
 SENSOR_TYPES = {
     'motion_recording': ['Motion Recording', None, 'motion-sensor', 'motion_recording']
 }
@@ -53,6 +55,7 @@ class UnifiProtectSensor(Entity):
         self._nvrdata = nvrdata
         self._icon = 'mdi:{}'.format(SENSOR_TYPES.get(self._sensor_type)[2])
         self._state = device['recording_mode']
+        self._camera_type = device['type']
         self._attr = SENSOR_TYPES.get(self._sensor_type)[3]
         _LOGGER.debug('UnifiProtectSensor: %s created', self._name)
 
@@ -88,6 +91,7 @@ class UnifiProtectSensor(Entity):
 
         attrs[ATTR_ATTRIBUTION] = ATTRIBUTION
         attrs['brand'] = DEFAULT_BRAND
+        attrs[ATTR_CAMERA_TYPE] = self._camera_type
         attrs['friendly_name'] = self._name
 
         return attrs

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -1,8 +1,9 @@
-
-camera.upv_request_thumbnail_to_file:
-  description: Request the lates motion thumbnail from a camera and write it to a file
+unifiprotect_save_thumbnail:
+  description: 'Request the lates motion thumbnail from a camera and write it to a file'
   fields:
     entity_id:
-      description: string (required) camera to get thumbnail from
+      description: 'string (required) camera to get thumbnail from'
+      example: 'camera.outdoor'
     filename:
-      description: string (required) where to save the thumbnail
+      description: 'string (required) where to save the thumbnail'
+      example: '/config/www/thumbnail.png'

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -1,0 +1,8 @@
+
+camera.upv_request_thumbnail_to_file:
+  description: Request the lates motion thumbnail from a camera and write it to a file
+  fields:
+    entity_id:
+      description: string (required) camera to get thumbnail from
+    filename:
+      description: string (required) where to save the thumbnail


### PR DESCRIPTION
* `binary_sensor_`:
  * Changed default SCAN_INTERVAL to 3 seconds to optimize Motion Detection
* `camera`:
  * Added new service `camera.unifiprotect_save_thumbnail`. When calling this services the Thumbnail of the last recorded motion will be saved to disk, and could then be used in an automation, to send to a phone via the `notify` platform. Requires `entity_id` and `filename` as attributes.
* `sensor`:
  * Added new attribute `camera_type` to the sensor. Showing what type of Unfi Camera is attached to this sensor
* `Core Module`
  * changed size of the thumbnail image when being created.
  * fixed error when no *Last Motion* record exist
  * cleaned up the code, removing obsolete parts.