### PR TITLE
V0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 * `camera`:
   * **BREAKING CHANGE** The service `camera.unifiprotect_save_thumbnail` has been removed, and has been replaced by a new Service you can read more about below. The implementation was not done according to Home Assistant standards, so I decided to rewrite it. If you use this Service in any automation, please replace it with the new Service.
   * A new Service with the name of `unifiprotect.save_thumbnail_image` has been created. This Service does exactly the same as the old service, but now it conforms to Home Assistant standards, and when you select it in the *Services* area under *Developer Tools* you will now see a proper Service Description. A new optional parameter has been added called `image_width`. Here you can specify the width of the image in pixels, and the height will then be scaled propotionally.
-
+* `core`:
+  * The function `set_camera_recording` was not using the *request.session*, resulting in occasional authentication errors.
 
 ## Version 0.0.8
 * `camera`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.0.9
+* `camera`:
+  * **BREAKING CHANGE** The service `camera.unifiprotect_save_thumbnail` has been removed, and has been replaced by a new Service you can read more about below. The implementation was not done according to Home Assistant standards, so I decided to rewrite it. If you use this Service in any automation, please replace it with the new Service.
+  * A new Service with the name of `unifiprotect.save_thumbnail_image` has been created. This Service does exactly the same as the old service, but now it conforms to Home Assistant standards, and when you select it in the *Services* area under *Developer Tools* you will now see a proper Service Description. A new optional parameter has been added called `image_width`. Here you can specify the width of the image in pixels, and the height will then be scaled propotionally.
+
+
 ## Version 0.0.8
 * `camera`:
   * Attributes update more frequently, to show recording mode and online status. Let me know if this causes any issues, as I achieve this by asking the Cameras to poll status every 30 seconds, and that is usually the case for a camera entity. In my own tests I have not seen any problems.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Service | Parameters | Description
 `camera.enable_motion_detection` | `entity_id` - camera to enable motion on | Enable motion detection on the specified camera
 `camera.snapshot` | `entity_id` - Name of entity to create snapshots from.<br>`filename` - Filename to store snapshot in | Take a snapshot of the current image on the specified camera and stor in a file
 `camera.record` | `entity_id` - camera to record from<br>`filename` - Template of a Filename. Variable is entity_id. Must be mp4.<br>`duration` - (Optional) Target recording length (in seconds).<br>`lookback` - (Optional) Target lookback period (in seconds) to include in addition to duration. Only available if there is currently an active HLS stream. | Record the current stream to a file
-`camera.unifiprotect_save_thumbnail` | `entity_id` - Name of entity to retrieve thumbnail from.<br>`filename` - Filename to store thumbnail in | Get the thumbnail image of the last recording event (If any), from the specified camera
+`unifiprotect.save_thumbnail_image` | `entity_id` - Name of entity to retrieve thumbnail from.<br>`filename` - Filename to store thumbnail in | Get the thumbnail image of the last recording event (If any), from the specified camera<br>`image_width` - (Optional) Width of the image in pixels. Height will be scaled proportionally. Default is 640.
 
 
 **Note:** When using *camera.enable_motion_detection*, Recording in Unfi Protect will be set to *motion*. If you want to have the cameras recording all the time, you have to set that in Unifi Protect App.

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -4,19 +4,22 @@ import voluptuous as vol
 import requests
 from . import protectnvr as nvr
 
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_HOST, CONF_PORT, CONF_SSL, CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_HOST, CONF_PORT, CONF_SSL, CONF_USERNAME, CONF_PASSWORD, CONF_FILENAME, ATTR_ENTITY_ID
 import homeassistant.helpers.config_validation as cv
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import Entity
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTRIBUTION = "Data provided by Unifi Protect NVR"
 DATA_UFP = "data_ufp"
-NVR = "nvr_ufp"
 DEFAULT_BRAND = "Ubiquiti"
+DEFAULT_THUMB_WIDTH = "640"
+CONF_IMAGE_WIDTH = "image_width"
+
+SERVICE_SAVE_THUMBNAIL = "save_thumbnail_image"
 
 DOMAIN = "unifiprotect"
 DEFAULT_ENTITY_NAMESPACE = "unifprotect"
@@ -39,6 +42,13 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+SAVE_THUMBNAIL_SCHEMA = vol.Schema(
+    {vol.Required(ATTR_ENTITY_ID): cv.entity_ids, 
+     vol.Required(CONF_FILENAME): cv.string, 
+     vol.Optional(CONF_IMAGE_WIDTH, default=DEFAULT_THUMB_WIDTH): cv.string
+     }
+)
+
 def setup(hass, config):
     """Set up the Unifi Protect component."""
     conf = config[DOMAIN]
@@ -51,7 +61,7 @@ def setup(hass, config):
     try:
         nvrobject = nvr.protectRemote(host,port,username,password,use_ssl)
         hass.data[DATA_UFP] = nvrobject
-
+                
     except nvr.NotAuthorized:
         _LOGGER.error("Authorization failure while connecting to NVR")
         return False
@@ -61,4 +71,47 @@ def setup(hass, config):
     except requests.exceptions.ConnectionError as ex:
         _LOGGER.error("Unable to connect to NVR: %s", str(ex))
         raise PlatformNotReady
+
+    async def async_save_thumbnail(call):
+        """Call save video service handler."""
+        await async_handle_save_thumbnail_service(hass, call)
+
+    hass.services.register(
+        DOMAIN, SERVICE_SAVE_THUMBNAIL, async_save_thumbnail, schema=SAVE_THUMBNAIL_SCHEMA
+    )
+    
     return True
+
+async def async_handle_save_thumbnail_service(hass, call):
+    """Handle save thumbnail service calls."""
+    # Get the Camera ID from Entity_id
+    entity_id = call.data[ATTR_ENTITY_ID]
+    entity_state = hass.states.get(entity_id[0])
+    camera_uuid = entity_state.attributes['uuid']
+    if camera_uuid is None:
+        _LOGGER.error("Unable to get Camera ID for selected Camera")
+        return
+
+    # Get other input from the service call
+    filename = call.data[CONF_FILENAME]
+    image_width = call.data[CONF_IMAGE_WIDTH]
+
+    if not hass.config.is_allowed_path(filename):
+        _LOGGER.error("Can't write %s, no access to path!", filename)
+        return    
+
+    def _write_thumbnail(camera_id, filename, image_width):
+        """Call thumbnail write."""
+        image_data = hass.data[DATA_UFP].get_thumbnail(camera_id, image_width)
+        if image_data is None:
+            _LOGGER.warning("Last recording not found for Camera %s", entity_state.attributes['friendly_name'])
+            return False
+        # We got an image, now write the image to disk
+        with open(filename, 'wb') as img_file:
+            img_file.write(image_data)
+
+    try:
+        await hass.async_add_executor_job(_write_thumbnail, camera_uuid, filename, image_width)
+    except OSError as err:
+        _LOGGER.error("Can't write image to file: %s", err)
+

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -61,6 +61,7 @@ def setup(hass, config):
     try:
         nvrobject = nvr.protectRemote(host,port,username,password,use_ssl)
         hass.data[DATA_UFP] = nvrobject
+        _LOGGER.debug("Connected to Unifi Protect Platform")
                 
     except nvr.NotAuthorized:
         _LOGGER.error("Authorization failure while connecting to NVR")

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -109,6 +109,7 @@ async def async_handle_save_thumbnail_service(hass, call):
         # We got an image, now write the image to disk
         with open(filename, 'wb') as img_file:
             img_file.write(image_data)
+            _LOGGER.debug("Thumbnail Image written to %s", filename)
 
     try:
         await hass.async_add_executor_job(_write_thumbnail, camera_uuid, filename, image_width)

--- a/custom_components/unifiprotect/camera.py
+++ b/custom_components/unifiprotect/camera.py
@@ -73,6 +73,8 @@ class UnifiVideoCamera(Camera):
 
         if (recording_mode != 'never' and self._online):
             self._isrecording = True
+            
+        _LOGGER.debug("Camera %s added to Home Assistant", self._name)
 
     @property
     def should_poll(self):

--- a/custom_components/unifiprotect/camera.py
+++ b/custom_components/unifiprotect/camera.py
@@ -6,8 +6,8 @@ from datetime import timedelta
 import requests
 import voluptuous as vol
 
-from homeassistant.components.camera import DOMAIN, SUPPORT_STREAM, PLATFORM_SCHEMA, CAMERA_SERVICE_SNAPSHOT, ATTR_FILENAME, Camera
-from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, CONF_USERNAME, CONF_PASSWORD, CONF_NAME, CONF_FILENAME, ATTR_ENTITY_ID
+from homeassistant.components.camera import DOMAIN, SUPPORT_STREAM, Camera
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, CONF_USERNAME, CONF_PASSWORD, CONF_NAME
 from homeassistant.exceptions import PlatformNotReady
 import homeassistant.helpers.config_validation as cv
 from . import ATTRIBUTION, DATA_UFP, DEFAULT_BRAND, protectnvr as nvr
@@ -16,13 +16,11 @@ from . import ATTRIBUTION, DATA_UFP, DEFAULT_BRAND, protectnvr as nvr
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=30)
-DEPENDENCIES = ['unifiprotect']
 
-SERVICE_SAVE_THUMBNAIL = "unifiprotect_save_thumbnail"
+DEPENDENCIES = ['unifiprotect']
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Discover cameras on a Unifi Protect NVR."""
-    component = hass.data[DOMAIN]
 
     try:
         # Exceptions may be raised in all method calls to the nvr library.
@@ -49,11 +47,6 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             for camera in cameras
         ]
     )
-
-    component.async_register_entity_service(
-        SERVICE_SAVE_THUMBNAIL, CAMERA_SERVICE_SNAPSHOT, save_thumbnail_service
-    )
-
 
     return True
 
@@ -128,6 +121,7 @@ class UnifiVideoCamera(Camera):
         attrs['up_since'] = self._up_since
         attrs['last_motion'] = self._last_motion
         attrs['online'] = self._online
+        attrs['uuid'] = self._uuid
         
         return attrs
 
@@ -173,14 +167,6 @@ class UnifiVideoCamera(Camera):
             self.async_camera_image(), self.hass.loop
         ).result()
 
-    def request_thumbnail(self):
-        image = self._nvr.get_thumbnail(self._uuid)
-        return image
-
-    def async_request_thumbnail(self):
-        _LOGGER.debug(self._uuid)
-        return self.hass.async_add_job(self.request_thumbnail)
-
     async def async_camera_image(self):
         """ Return the Camera Image. """
         last_image = self._nvr.get_snapshot_image(self._uuid)
@@ -190,34 +176,3 @@ class UnifiVideoCamera(Camera):
     async def stream_source(self):
         """ Return the Stream Source. """
         return self._stream_source
-
-async def save_thumbnail_service(camera, service):
-
-    hass = camera.hass
-    filename = service.data[ATTR_FILENAME]
-    filename.hass = hass
-
-    snapshot_file = filename.async_render(variables={ATTR_ENTITY_ID: camera})
-
-    # check if we allow to access to that file
-    if not hass.config.is_allowed_path(snapshot_file):
-        _LOGGER.error("Can't write %s, no access to path!", snapshot_file)
-        return
-
-    image = await camera.async_request_thumbnail()
-    if image is None:
-        _LOGGER.warning("Last recording not found for Camera " + camera.name)
-        return False
-
-    def _write_image(to_file, image_data):
-        with open(to_file, 'wb') as img_file:
-            img_file.write(image_data)
-
-    try:
-        await hass.async_add_executor_job(_write_image, snapshot_file, image)
-        hass.bus.fire('unifiprotect_thumbnail_ready', {
-            'entity_id': 'unifiprotect.' + camera.unique_id,
-            'file': snapshot_file
-        })
-    except OSError as err:
-        _LOGGER.error("Can't write image to file: %s", err)

--- a/custom_components/unifiprotect/protectnvr.py
+++ b/custom_components/unifiprotect/protectnvr.py
@@ -267,7 +267,7 @@ class protectRemote(object):
             print("Error Code: " + str(response.status_code) + " - Error Status: " + response.reason)
             return None
 
-    def get_thumbnail(self, cuid):
+    def get_thumbnail(self, cuid, width=640):
         """Returns the last recorded Thumbnail, based on Camera ID."""
         event_list = self.events
         event_list_sorted = sorted(event_list, key=lambda k: k['start'], reverse=True)
@@ -279,8 +279,9 @@ class protectRemote(object):
                 break
         
         if thumbnail_id is not None:
+            height = float(width)/1.8
             access_key = self._get_api_access_key()
-            img_uri = "https://" + str(self._host) + ":" + str(self._port) + "/api/thumbnails/" + str(thumbnail_id) + "?accessKey=" + access_key + "&h=240&w=427"
+            img_uri = "https://" + str(self._host) + ":" + str(self._port) + "/api/thumbnails/" + str(thumbnail_id) + "?accessKey=" + access_key + "&h=" + str(height) + "&w=" + str(width)
             response = self.req.get(img_uri, verify=self._verify_ssl)
             if response.status_code == 200:
                 return response.content

--- a/custom_components/unifiprotect/protectnvr.py
+++ b/custom_components/unifiprotect/protectnvr.py
@@ -238,7 +238,7 @@ class protectRemote(object):
 
         header = {'Authorization': 'Bearer ' + self._api_auth_bearer_token,'Content-Type': 'application/json'}
 
-        response = requests.patch(cam_uri, headers=header, verify=self._verify_ssl, json=data)
+        response = self.req.patch(cam_uri, headers=header, verify=self._verify_ssl, json=data)
         if response.status_code == 200:
             return True
         else:

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -1,4 +1,4 @@
-unifiprotect_save_thumbnail:
+save_thumbnail_image:
   description: 'Request the lates motion thumbnail from a camera and write it to a file'
   fields:
     entity_id:
@@ -7,3 +7,6 @@ unifiprotect_save_thumbnail:
     filename:
       description: 'string (required) where to save the thumbnail'
       example: '/config/www/thumbnail.png'
+    image_width:
+      description: 'string (optional) width of Thumbnail image in pixels'
+      example: '640'

--- a/info.md
+++ b/info.md
@@ -51,7 +51,7 @@ Service | Parameters | Description
 `camera.enable_motion_detection` | `entity_id` - camera to enable motion on | Enable motion detection on the specified camera
 `camera.snapshot` | `entity_id` - Name of entity to create snapshots from.<br>`filename` - Filename to store snapshot in | Take a snapshot of the current image on the specified camera and stor in a file
 `camera.record` | `entity_id` - camera to record from<br>`filename` - Template of a Filename. Variable is entity_id. Must be mp4.<br>`duration` - (Optional) Target recording length (in seconds).<br>`lookback` - (Optional) Target lookback period (in seconds) to include in addition to duration. Only available if there is currently an active HLS stream. | Record the current stream to a file
-`camera.unifiprotect_save_thumbnail` | `entity_id` - Name of entity to retrieve thumbnail from.<br>`filename` - Filename to store thumbnail in | Get the thumbnail image of the last recording event (If any), from the specified camera
+`unifiprotect.save_thumbnail_image` | `entity_id` - Name of entity to retrieve thumbnail from.<br>`filename` - Filename to store thumbnail in | Get the thumbnail image of the last recording event (If any), from the specified camera<br>`image_width` - (Optional) Width of the image in pixels. Height will be scaled proportionally. Default is 640.
 
 **Note:** When using *camera.enable_motion_detection*, Recording in Unfi Protect will be set to *motion*. If you want to have the cameras recording all the time, you have to set that in Unifi Protect App.
 


### PR DESCRIPTION
* `camera`:
  * **BREAKING CHANGE** The service `camera.unifiprotect_save_thumbnail` has been removed, and has been replaced by a new Service you can read more about below. The implementation was not done according to Home Assistant standards, so I decided to rewrite it. If you use this Service in any automation, please replace it with the new Service.
  * A new Service with the name of `unifiprotect.save_thumbnail_image` has been created. This Service does exactly the same as the old service, but now it conforms to Home Assistant standards, and when you select it in the *Services* area under *Developer Tools* you will now see a proper Service Description. A new optional parameter has been added called `image_width`. Here you can specify the width of the image in pixels, and the height will then be scaled propotionally.
* `core`:
  * The function `set_camera_recording` was not using the *request.session*, resulting in occasional authentication errors.