### PR TITLE
V0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.1.2
+
+* `New`:
+  * Added a new *Switch* component. If enabled the system will create a switch for each camera, that can enable or disable the motion recording. You can already do this by running the services `camera.enable_motion_detection` and `camera.disable_motion_detection` but this gives a convenient way to do it from the Frontend. See the [Github README.md](https://github.com/briis/unifiprotect/blob/master/README.md) for setup instructions.
+
 ## Version 0.1.1
 
 Minor update

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Basically what this does, is integrating the Camera feeds from Unifi Protect in 
 Before you install this Integration you need to ensure that the following two settings are applied in Unifi Protect:
 
 1. **Local User needs to be added** Open Unifi Protect in your browser. Click the USERS tab and you will get a list of users. Either select an existing user, or create a new one. The important thing is that the user is part of *Administrators* and that a local username and password is set for that user. This is the username and password you will use when setting up the Integration later.
-2. **RTSP Stream** Select each camera under the CAMERAS tab, click on the camera and you will get a menu on the right side. Click the MANAGE button and there will be a menu like the picture below. (If you can't see the same picture click the + sign to the right of RTSP). Make sure that at least one of the streams is set to on. It does not matter which one, or if you select more than one. The integration will pick the one with the highest resolution.  
+2. **RTSP Stream** Select each camera under the CAMERAS tab, click on the camera and you will get a menu on the right side. Click the MANAGE button and there will be a menu like the picture below. (If you can't see the same picture click the + sign to the right of RTSP). Make sure that at least one of the streams is set to on. It does not matter which one, or if you select more than one, the integration will pick the one with the highest resolution.  
 
 ![USER Settings](https://github.com/briis/unifiprotect/blob/master/images/setup_user.png) ![RTSP Settings](https://github.com/briis/unifiprotect/blob/master/images/setup_rtsp.png)
 

--- a/README.md
+++ b/README.md
@@ -134,3 +134,15 @@ The sensor can have 3 different states:
 1. `never` - There will be no recording on the camera
 2. `motion` - Recording will happen only when motion is detected
 3. `always` - The camera will record everything, and motion events will be logged in Unfi Protect
+
+### Switch
+
+If this component is enabled a Switch to enable or disable motion recording for each camera, will be created.
+
+In order to use the Switch, add the following to your *configuration.yaml* file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: unifiprotect
+```

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -5,7 +5,6 @@ import logging
 import voluptuous as vol
 import requests
 
-# from . import protectnvr as nvr
 from . import unifi_protect_server as upv
 
 from homeassistant.const import (
@@ -98,8 +97,6 @@ def setup(hass, config):
         hass.data[UPV_DATA] = upv.UpvServer(
             host, port, username, password, use_ssl, minimum_score
         )
-        # nvrobject = nvr.ProtectServer(host, port, username, password, use_ssl)
-        # hass.data[DATA_UFP] = nvrobject
         _LOGGER.debug("Connected to Unifi Protect Platform")
 
     except upv.NotAuthorized:

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -41,7 +41,6 @@ async def async_setup_platform(hass, config, async_add_entities, _discovery_info
     sensors = []
     for sensor_type in config.get(CONF_MONITORED_CONDITIONS):
         for camera in data.devices:
-            # name = "{0} {1}".format(SENSOR_TYPES[sensor_type][0], camera["name"])
             sensors.append(UnifiProtectSensor(data, camera, sensor_type))
 
     async_add_entities(sensors, True)

--- a/custom_components/unifiprotect/switch.py
+++ b/custom_components/unifiprotect/switch.py
@@ -54,7 +54,6 @@ class UnifiProtectSwitch(SwitchDevice):
         self._camera_id = camera
         self._camera = self.data.devices[camera]
         self._name = "{0} {1} {2}".format(DOMAIN.capitalize(), SWITCH_TYPES[switch_type][0], self._camera["name"])
-#        self._friendly_name = "{0} {1}".format(SWITCH_TYPES[switch_type][0], self._camera["name"])
         self._unique_id = self._name.lower().replace(" ", "_")
         self._icon = "mdi:{}".format(SWITCH_TYPES.get(switch_type)[1])
         self._state = STATE_OFF
@@ -95,7 +94,6 @@ class UnifiProtectSwitch(SwitchDevice):
         attrs[ATTR_ATTRIBUTION] = DEFAULT_ATTRIBUTION
         attrs[ATTR_BRAND] = DEFAULT_BRAND
         attrs[ATTR_CAMERA_TYPE] = self._camera_type
-#        attrs[ATTR_FRIENDLY_NAME] = self._friendly_name
 
         return attrs
 

--- a/custom_components/unifiprotect/switch.py
+++ b/custom_components/unifiprotect/switch.py
@@ -1,0 +1,116 @@
+""" This component provides Switches for Unifi Protect."""
+
+import logging
+import voluptuous as vol
+from datetime import timedelta
+
+import homeassistant.helpers.config_validation as cv
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
+from homeassistant.const import ATTR_ATTRIBUTION, ATTR_FRIENDLY_NAME, CONF_MONITORED_CONDITIONS, STATE_OFF, STATE_ON
+from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
+
+from . import UPV_DATA, DEFAULT_ATTRIBUTION, DEFAULT_BRAND
+
+_LOGGER = logging.getLogger(__name__)
+
+DEPENDENCIES = ["unifiprotect"]
+
+SCAN_INTERVAL = timedelta(seconds=2)
+
+ATTR_CAMERA_TYPE = "camera_type"
+ATTR_BRAND = "brand"
+
+SWITCH_TYPES = {
+    "recording": ["Recording", None, "camcorder", "motion_recording"]
+}
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_MONITORED_CONDITIONS, default=list(SWITCH_TYPES)): vol.All(
+            cv.ensure_list, [vol.In(SWITCH_TYPES)]
+        ),
+    }
+)
+
+async def async_setup_platform(hass, config, async_add_entities, _discovery_info=None):
+    """Set up an Unifi Protect Switch."""
+    data = hass.data[UPV_DATA]
+    if not data:
+        return
+
+    switches = []
+    for switch_type in config.get(CONF_MONITORED_CONDITIONS):
+        for camera in data.devices:
+            switches.append(UnifiProtectSwitch(data, camera, switch_type))
+
+    async_add_entities(switches, True)
+
+class UnifiProtectSwitch(SwitchDevice):
+    """A Unifi Protect Binary Sensor."""
+
+    def __init__(self, data, camera, switch_type):
+        """Initialize an Unifi Protect sensor."""
+        self.data = data
+        self._camera_id = camera
+        self._camera = self.data.devices[camera]
+        self._name = "{0} {1}".format(SWITCH_TYPES[switch_type][0], self._camera["name"])
+        self._unique_id = self._name.lower().replace(" ", "_")
+        self._icon = "mdi:{}".format(SWITCH_TYPES.get(switch_type)[2])
+        self._state = STATE_OFF
+        self._camera_type = self._camera["type"]
+        self._attr = SWITCH_TYPES.get(switch_type)[3]
+        _LOGGER.debug("UnifiProtectSwitch: %s created", self._name)
+
+    @property
+    def should_poll(self):
+        """Poll for status regularly."""
+        return True
+
+    @property
+    def name(self):
+        """Return the name of the device if any."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device if any."""
+        return self._state
+
+    @property
+    def is_on(self):
+        """Return true if device is on."""
+        return self._state == STATE_ON
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        attrs = {}
+
+        attrs[ATTR_ATTRIBUTION] = DEFAULT_ATTRIBUTION
+        attrs[ATTR_BRAND] = DEFAULT_BRAND
+        attrs[ATTR_CAMERA_TYPE] = self._camera_type
+        attrs[ATTR_FRIENDLY_NAME] = self._name
+
+        return attrs
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        _LOGGER.debug("Turning on Motion Detection ")
+        self.data.set_camera_recording(self._camera_id, "motion")
+
+    def turn_off(self, **kwargs):
+        """Turn the device off."""
+        _LOGGER.debug("Turning off Motion Detection ")
+        self.data.set_camera_recording(self._camera_id, "never")
+
+    def update(self):
+        """Update Motion Detection state."""
+        enabled = True if self._camera["recording_mode"] != "never" else False
+        _LOGGER.debug("enabled: %s", enabled)
+        self._state = STATE_ON if enabled else STATE_OFF
+

--- a/custom_components/unifiprotect/switch.py
+++ b/custom_components/unifiprotect/switch.py
@@ -9,19 +9,19 @@ from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_FRIENDLY_NAME, CONF_MONITORED_CONDITIONS, STATE_OFF, STATE_ON
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 
-from . import UPV_DATA, DEFAULT_ATTRIBUTION, DEFAULT_BRAND
+from . import UPV_DATA, DEFAULT_ATTRIBUTION, DEFAULT_BRAND, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["unifiprotect"]
 
-SCAN_INTERVAL = timedelta(seconds=2)
+SCAN_INTERVAL = timedelta(seconds=3)
 
 ATTR_CAMERA_TYPE = "camera_type"
 ATTR_BRAND = "brand"
 
 SWITCH_TYPES = {
-    "recording": ["Recording", None, "camcorder", "motion_recording"]
+    "recording": ["Recording", "camcorder", "motion_recording"]
 }
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -46,19 +46,20 @@ async def async_setup_platform(hass, config, async_add_entities, _discovery_info
     async_add_entities(switches, True)
 
 class UnifiProtectSwitch(SwitchDevice):
-    """A Unifi Protect Binary Sensor."""
+    """A Unifi Protect Switch."""
 
     def __init__(self, data, camera, switch_type):
-        """Initialize an Unifi Protect sensor."""
+        """Initialize an Unifi Protect Switch."""
         self.data = data
         self._camera_id = camera
         self._camera = self.data.devices[camera]
-        self._name = "{0} {1}".format(SWITCH_TYPES[switch_type][0], self._camera["name"])
+        self._name = "{0} {1} {2}".format(DOMAIN.capitalize(), SWITCH_TYPES[switch_type][0], self._camera["name"])
+#        self._friendly_name = "{0} {1}".format(SWITCH_TYPES[switch_type][0], self._camera["name"])
         self._unique_id = self._name.lower().replace(" ", "_")
-        self._icon = "mdi:{}".format(SWITCH_TYPES.get(switch_type)[2])
+        self._icon = "mdi:{}".format(SWITCH_TYPES.get(switch_type)[1])
         self._state = STATE_OFF
         self._camera_type = self._camera["type"]
-        self._attr = SWITCH_TYPES.get(switch_type)[3]
+        self._attr = SWITCH_TYPES.get(switch_type)[2]
         _LOGGER.debug("UnifiProtectSwitch: %s created", self._name)
 
     @property
@@ -94,7 +95,7 @@ class UnifiProtectSwitch(SwitchDevice):
         attrs[ATTR_ATTRIBUTION] = DEFAULT_ATTRIBUTION
         attrs[ATTR_BRAND] = DEFAULT_BRAND
         attrs[ATTR_CAMERA_TYPE] = self._camera_type
-        attrs[ATTR_FRIENDLY_NAME] = self._name
+#        attrs[ATTR_FRIENDLY_NAME] = self._friendly_name
 
         return attrs
 

--- a/custom_components/unifiprotect/unifi_protect_server.py
+++ b/custom_components/unifiprotect/unifi_protect_server.py
@@ -326,6 +326,7 @@ class UpvServer:
             cam_uri, headers=header, verify=self._verify_ssl, json=data
         )
         if response.status_code == 200:
+            self.device_data[camera_id]["recording_mode"] = mode
             return True
         else:
             raise NvrError(

--- a/info.md
+++ b/info.md
@@ -103,3 +103,15 @@ The sensor can have 3 different states:
 1. `never` - There will be no recording on the camera
 2. `motion` - Recording will happen only when motion is detected
 3. `always` - The camera will record everything, and motion events will be logged in Unfi Protect
+
+### Switch
+
+If this component is enabled a Switch to enable or disable motion recording for each camera, will be created.
+
+In order to use the Switch, add the following to your *configuration.yaml* file:
+
+```yaml
+# Example configuration.yaml entry
+switch:
+  - platform: unifiprotect
+```


### PR DESCRIPTION
* `New`:
  * Added a new *Switch* component. If enabled the system will create a switch for each camera, that can enable or disable the motion recording. You can already do this by running the services `camera.enable_motion_detection` and `camera.disable_motion_detection` but this gives a convenient way to do it from the Frontend. See the [Github README.md](https://github.com/briis/unifiprotect/blob/master/README.md) for setup instructions.