### PR TITLE
V0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 0.1.3
 
 * **Breaking Change** The Switch component has changed due to implementation of a new Switch. The previous switch name `switch.unifiprotect_recording_[camera Name]` does no longer exist. It has been replaced by two new switches `switch.unifiprotect_record_motion_[Camera Name]` and `switch.unifiprotect_record_always_[Camera Name]`. This first set recording mode to *motion* and the second set recording mode to *always*. They are mutually exclusive, so turning on one, will turn off the other.
-* **New**: Added new Service `unifiprotect.enable_always_recording`. When called, this service set recording mode for the chosen camera to *Always*, meaning that camera records all the time. Motion detection is still active with this mode set. 
+* **New**: Added new Service `unifiprotect.enable_always_recording`. When called, this service set recording mode for the chosen camera to *Always*, meaning that camera records all the time. Motion detection is still active with this mode set.
 * **Change**: Cleaned up some unused code
 
 ## Version 0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
+## Version 0.1.3
+
+* **New**: Added new Service `unifiprotect.enable_always_recording`. When called, this service set recording mode for the chosen camera to *Always*, meaning that camera records all the time. Motion detection is still active with this mode set. 
+* **Change**: Cleaned up some unused code
+
 ## Version 0.1.2
 
-* `New`:
-  * Added a new *Switch* component. If enabled the system will create a switch for each camera, that can enable or disable the motion recording. You can already do this by running the services `camera.enable_motion_detection` and `camera.disable_motion_detection` but this gives a convenient way to do it from the Frontend. See the [Github README.md](https://github.com/briis/unifiprotect/blob/master/README.md) for setup instructions.
+* **New**: Added a new *Switch* component. If enabled the system will create a switch for each camera, that can enable or disable the motion recording. You can already do this by running the services `camera.enable_motion_detection` and `camera.disable_motion_detection` but this gives a convenient way to do it from the Frontend. See the [Github README.md](https://github.com/briis/unifiprotect/blob/master/README.md) for setup instructions.
+* **Change**: Cleaned up some unused code
 
 ## Version 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.1.3
 
+* **Breaking Change** The Switch component has changed due to implementation of a new Switch. The previous switch name `switch.unifiprotect_recording_[camera Name]` does no longer exist. It has been replaced by two new switches `switch.unifiprotect_record_motion_[Camera Name]` and `switch.unifiprotect_record_always_[Camera Name]`. This first set recording mode to *motion* and the second set recording mode to *always*. They are mutually exclusive, so turning on one, will turn off the other.
 * **New**: Added new Service `unifiprotect.enable_always_recording`. When called, this service set recording mode for the chosen camera to *Always*, meaning that camera records all the time. Motion detection is still active with this mode set. 
 * **Change**: Cleaned up some unused code
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Version 0.1.3
 
-* **Breaking Change** The Switch component has changed due to implementation of a new Switch. The previous switch name `switch.unifiprotect_recording_[camera Name]` does no longer exist. It has been replaced by two new switches `switch.unifiprotect_record_motion_[Camera Name]` and `switch.unifiprotect_record_always_[Camera Name]`. This first set recording mode to *motion* and the second set recording mode to *always*. They are mutually exclusive, so turning on one, will turn off the other.
-* **New**: Added new Service `unifiprotect.enable_always_recording`. When called, this service set recording mode for the chosen camera to *Always*, meaning that camera records all the time. Motion detection is still active with this mode set.
+* **Breaking Change** The Switch component has changed due to implementation of a new Switch. The previous switch name `switch.unifiprotect_recording_[camera Name]` does no longer exist. It has been replaced by two new switches `switch.unifiprotect_record_motion_[Camera Name]` and `switch.unifiprotect_record_always_[Camera Name]`. The first sets recording mode to *motion* and the second sets recording mode to *always*. They are mutually exclusive, so turning on one, will turn off the other.
+* **New**: Added new Service `unifiprotect.set_recording_mode`. When called, this service sets the recording mode for the chosen camera to the specified *recording_mode*. The value can be `always`, `motion` or `never`. The mode *always*, will let the camera record all the time, *motion* is the usual motion recording and *never* disables all recording.
 * **Change**: Cleaned up some unused code
 
 ## Version 0.1.2

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Service | Parameters | Description
 `camera.snapshot` | `entity_id` - Name of entity to create snapshots from.<br>`filename` - Filename to store snapshot in | Take a snapshot of the current image on the specified camera and stor in a file
 `camera.record` | `entity_id` - camera to record from<br>`filename` - Template of a Filename. Variable is entity_id. Must be mp4.<br>`duration` - (Optional) Target recording length (in seconds).<br>`lookback` - (Optional) Target lookback period (in seconds) to include in addition to duration. Only available if there is currently an active HLS stream. | Record the current stream to a file
 `unifiprotect.save_thumbnail_image` | `entity_id` - Name of entity to retrieve thumbnail from.<br>`filename` - Filename to store thumbnail in<br>`image_width` - (Optional) Width of the image in pixels. Height will be scaled proportionally. Default is 640. | Get the thumbnail image of the last recording event (If any), from the specified camera
+`unifiprotect.set_recording_mode` | `entity_id` - Name of entity to set recording mode for.<br>`recording_mode` - always, motion or never< | Set the recording mode for each Camera.
 
 **Note:** When using *camera.enable_motion_detection*, Recording in Unfi Protect will be set to *motion*. If you want to have the cameras recording all the time, you have to set that in Unifi Protect App.
 
@@ -141,7 +142,7 @@ The sensor can have 3 different states:
 
 ### Switch
 
-If this component is enabled a Switch to enable or disable motion recording for each camera, will be created.
+If this component is enabled two Switches are created per Camera. One to enable or disable motion recording and one to enable or disable constant recording for each camera.
 
 In order to use the Switch, add the following to your *configuration.yaml* file:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Before you install this Integration you need to ensure that the following two se
 
 ![USER Settings](https://github.com/briis/unifiprotect/blob/master/images/setup_user.png) ![RTSP Settings](https://github.com/briis/unifiprotect/blob/master/images/setup_rtsp.png)
 
-**Note:** This has been testet on Unifi Protect Controller with version 1.13.0-beta.16 and higher. I cannot guarantee that this will work on a lower version than that.
+**Note:**  
+
+* This has been testet on a Cloud Key Gen2+ with Unifi Protect Controller version 1.13.0-beta.16 and higher. I cannot guarantee that this will work on a lower version than that.
+* It is **not working** with *UnifiOS* that is currently being shipped with the Unifi Dream Machine Pro in the US. I have no access to a system like that, so I don't know when and if, that can be supported.
 
 ## Manual Installation
 
@@ -33,6 +36,7 @@ manifest.json
 sensor.py
 binary_sensor.py
 camera.py
+switch.py
 unifi_protect_server.py
 services.yaml
 ```

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -160,6 +160,8 @@ async def async_handle_set_recording_mode(hass, call):
         return
     
     rec_mode = call.data[CONF_RECORDING_MODE].lower()
+    if rec_mode not in {"always", "motion", "never"}:
+        rec_mode = "motion"
 
     def _set_recording_mode(camera_id, recording_mode):
         """Communicate with Camera and set recording mode."""

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -50,6 +50,10 @@ DEFAULT_SCAN_INTERVAL = timedelta(seconds=2)
 DEFAULT_SSL = False
 DEFAULT_THUMB_WIDTH = 640
 
+TYPE_RECORD_MOTION = "motion"
+TYPE_RECORD_ALLWAYS = "always"
+TYPE_RECORD_NEVER = "never"
+
 DOMAIN = "unifiprotect"
 UPV_DATA = DOMAIN
 

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -7,7 +7,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_FRIENDLY_NAME, CONF_MONITORED_CONDITIONS
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import Entity
-from . import UPV_DATA, DEFAULT_ATTRIBUTION, DEFAULT_BRAND
+from . import UPV_DATA, DEFAULT_ATTRIBUTION, DEFAULT_BRAND, TYPE_RECORD_NEVER
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,4 +104,4 @@ class UnifiProtectSensor(Entity):
         """ Updates Motions State."""
 
         self._state = self._camera["recording_mode"]
-        self._icon = "mdi:camcorder" if self._state != "never" else "mdi:camcorder-off"
+        self._icon = "mdi:camcorder" if self._state != TYPE_RECORD_NEVER else "mdi:camcorder-off"

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -17,5 +17,5 @@ set_recording_mode:
       description: 'string (required) camera to enable recording on'
       example: 'camera.outdoor'
     recording_mode:
-      description: '(Optional) Valid options are: always = Always Recording, motion = Only record on motion, never = stop recording'
+      description: '(Optional) Valid options are: always = Always Recording, motion = Only record on motion, never = stop recording. Default value is: motion'
       example: always

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -10,9 +10,12 @@ save_thumbnail_image:
     image_width:
       description: 'string (optional) width of Thumbnail image in pixels'
       example: '640'
-enable_always_recording:
-  description: 'Set recording mode for the camera to Always'
+set_recording_mode:
+  description: 'Set recording mode for the camera'
   fields:
     entity_id:
       description: 'string (required) camera to enable recording on'
       example: 'camera.outdoor'
+    recording_mode:
+      description: '(Optional) Valid options are: always = Always Recording, motion = Only record on motion, never = stop recording'
+      example: always

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -10,3 +10,9 @@ save_thumbnail_image:
     image_width:
       description: 'string (optional) width of Thumbnail image in pixels'
       example: '640'
+enable_always_recording:
+  description: 'Set recording mode for the camera to Always'
+  fields:
+    entity_id:
+      description: 'string (required) camera to enable recording on'
+      example: 'camera.outdoor'


### PR DESCRIPTION
* **Breaking Change** The Switch component has changed due to implementation of a new Switch. The previous switch name `switch.unifiprotect_recording_[camera Name]` does no longer exist. It has been replaced by two new switches `switch.unifiprotect_record_motion_[Camera Name]` and `switch.unifiprotect_record_always_[Camera Name]`. The first sets recording mode to *motion* and the second sets recording mode to *always*. They are mutually exclusive, so turning on one, will turn off the other.
* **New**: Added new Service `unifiprotect.set_recording_mode`. When called, this service sets the recording mode for the chosen camera to the specified *recording_mode*. The value can be `always`, `motion` or `never`. The mode *always*, will let the camera record all the time, *motion* is the usual motion recording and *never* disables all recording.
* **Change**: Cleaned up some unused code