### PR TITLE
V0.1.6

### DIFF
--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 DEPENDENCIES = ["unifiprotect"]
 
 # Update Frequently as we are only reading from Memory
-SCAN_INTERVAL = timedelta(seconds=2)
+SCAN_INTERVAL = timedelta(seconds=10)
 
 ATTR_CAMERA_TYPE = "camera_type"
 ATTR_BRAND = "brand"

--- a/custom_components/unifiprotect/switch.py
+++ b/custom_components/unifiprotect/switch.py
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["unifiprotect"]
 
-SCAN_INTERVAL = timedelta(seconds=3)
+SCAN_INTERVAL = timedelta(seconds=5)
 
 ATTR_CAMERA_TYPE = "camera_type"
 ATTR_BRAND = "brand"

--- a/custom_components/unifiprotect/unifi_protect_server.py
+++ b/custom_components/unifiprotect/unifi_protect_server.py
@@ -28,7 +28,7 @@ class UpvServer:
     """Updates device States and Attributes."""
 
     def __init__(
-        self, host, port, username, password, verify_ssl=False, minimum_score=40
+        self, host, port, username, password, verify_ssl=False, minimum_score=0
     ):
         self._host = host
         self._port = port
@@ -168,7 +168,6 @@ class UpvServer:
                             "motion_score": 0,
                             "motion_thumbnail": None,
                             "motion_on": False,
-                            "motion_events_today": 0,
                         }
                     }
                     self.device_data.update(item)
@@ -214,15 +213,19 @@ class UpvServer:
                     start_time = datetime.datetime.fromtimestamp(
                         int(event["start"]) / 1000
                     ).strftime("%Y-%m-%d %H:%M:%S")
+                    if int(event["score"]) >= self._minimum_score:
+                        motion_on = True
+                    else:
+                        motion_on = False
                 else:
                     start_time = None
                 if event["end"]:
                     motion_on = False
-                else:
-                    if int(event["score"]) > self._minimum_score:
-                        motion_on = True
-                    else:
-                        motion_on = False
+                # else:
+                #     if int(event["score"]) >= self._minimum_score:
+                #         motion_on = True
+                #     else:
+                #         motion_on = False
 
                 camera_id = event["camera"]
                 self.device_data[camera_id]["motion_start"] = start_time

--- a/custom_components/unifiprotect/unifi_protect_server.py
+++ b/custom_components/unifiprotect/unifi_protect_server.py
@@ -178,6 +178,11 @@ class UpvServer:
                     self.device_data[camera_id]["up_since"] = upsince
                     self.device_data[camera_id]["recording_mode"] = recording_mode
                     self.device_data[camera_id]["ir_mode"] = ir_mode
+        else:
+            raise NvrError(
+                "Fetching Camera List failed: %s - Reason: %s"
+                % (response.status_code, response.reason)
+            )
 
     def _get_motion_events(self, lookback=86400):
         """Load the Event Log and loop through items to find motion events."""
@@ -235,7 +240,7 @@ class UpvServer:
                     self.device_data[camera_id]["motion_thumbnail"] = event["thumbnail"]
         else:
             raise NvrError(
-                "Fetching Eventlog failed failed: %s - Reason: %s"
+                "Fetching Eventlog failed: %s - Reason: %s"
                 % (response.status_code, response.reason)
             )
                       

--- a/custom_components/unifiprotect/unifi_protect_server.py
+++ b/custom_components/unifiprotect/unifi_protect_server.py
@@ -216,16 +216,12 @@ class UpvServer:
                     start_time = datetime.datetime.fromtimestamp(
                         int(event["start"]) / 1000
                     ).strftime("%Y-%m-%d %H:%M:%S")
-                    # if int(event["score"]) >= 0:   #self._minimum_score:
-                    #     motion_on = True
-                    # else:
-                    #     motion_on = False
                 else:
                     start_time = None
                 if event["end"]:
                     motion_on = False
                 else:
-                    if int(event["score"]) >= 0:   # self._minimum_score:
+                    if int(event["score"]) >= self._minimum_score:
                         motion_on = True
                     else:
                         motion_on = False

--- a/custom_components/unifiprotect/unifi_protect_server.py
+++ b/custom_components/unifiprotect/unifi_protect_server.py
@@ -205,10 +205,8 @@ class UpvServer:
             verify=self._verify_ssl,
         )
         if response.status_code == 200:
-            # print("Successfully retrieved data from /api/events")
             events = response.json()
             for event in events:
-                # print("Event for camera: " + str(event['camera']))
                 if event["start"]:
                     start_time = datetime.datetime.fromtimestamp(
                         int(event["start"]) / 1000
@@ -235,7 +233,12 @@ class UpvServer:
                     event["thumbnail"] is not None
                 ):  # Only update if there is a new Motion Event
                     self.device_data[camera_id]["motion_thumbnail"] = event["thumbnail"]
-
+        else:
+            raise NvrError(
+                "Fetching Eventlog failed failed: %s - Reason: %s"
+                % (response.status_code, response.reason)
+            )
+                      
     def get_thumbnail(self, camera_id, width=640):
         """Returns the last recorded Thumbnail, based on Camera ID."""
 

--- a/custom_components/unifiprotect/unifi_protect_server.py
+++ b/custom_components/unifiprotect/unifi_protect_server.py
@@ -216,19 +216,19 @@ class UpvServer:
                     start_time = datetime.datetime.fromtimestamp(
                         int(event["start"]) / 1000
                     ).strftime("%Y-%m-%d %H:%M:%S")
-                    if int(event["score"]) >= self._minimum_score:
-                        motion_on = True
-                    else:
-                        motion_on = False
+                    # if int(event["score"]) >= 0:   #self._minimum_score:
+                    #     motion_on = True
+                    # else:
+                    #     motion_on = False
                 else:
                     start_time = None
                 if event["end"]:
                     motion_on = False
-                # else:
-                #     if int(event["score"]) >= self._minimum_score:
-                #         motion_on = True
-                #     else:
-                #         motion_on = False
+                else:
+                    if int(event["score"]) >= 0:   # self._minimum_score:
+                        motion_on = True
+                    else:
+                        motion_on = False
 
                 camera_id = event["camera"]
                 self.device_data[camera_id]["motion_start"] = start_time


### PR DESCRIPTION
### Breaking
The latest Beta version of Unifi Protect on the Cloud Key+ (Version 1.13.3-beta.1) has introduced changes in the API and the way data is updated. The result of that is that the `motion_score` parameter is now only updated when the event has finished - previously it was updated when motion occurred. So if you have set the motion_score in the configuration to a number higher than 0, then you will most likely see that your Binary Motion Sensors never trigger. Currently the only way to fix this, is to set it to 0, or remove it from `configuration.yaml`. 

This release ensures that even though the value is 0, it will still trigger motion.
