### PR TITLE
Handle authentication token expiration for UnifiOS

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,19 +1,21 @@
 default_config:
-    cloud:
-    
-    stream:
-    
-    unifiprotect:
-      host: 192.168.1.1
-      port: 443
-      username: !secret unifiprotect_user
-      password: !secret unifiprotect_password
-    
-    camera:
-      - platform: unifiprotect
-    
-    logger:
-      default: error
-      logs:
-        custom_components.unifiprotect: debug
-        
+cloud:
+
+stream:
+
+unifiprotect:
+  host: 192.168.1.1
+  port: 443
+  username: !secret unifiprotect_user
+  password: !secret unifiprotect_password
+
+camera:
+  - platform: unifiprotect
+
+binary_sensor:
+  - platform: unifiprotect
+
+logger:
+  default: error
+  logs:
+    custom_components.unifiprotect: debug

--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -4,8 +4,8 @@ cloud:
 stream:
 
 unifiprotect:
-  host: 192.168.1.1
-  port: 443
+  host: !secret unifiprotect_host
+  port: !secret unifiprotect_port
   username: !secret unifiprotect_user
   password: !secret unifiprotect_password
 

--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,0 +1,19 @@
+default_config:
+    cloud:
+    
+    stream:
+    
+    unifiprotect:
+      host: 192.168.1.1
+      port: 443
+      username: !secret unifiprotect_user
+      password: !secret unifiprotect_password
+    
+    camera:
+      - platform: unifiprotect
+    
+    logger:
+      default: error
+      logs:
+        custom_components.unifiprotect: debug
+        

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+{
+	"name": "Home Assistant Unifi Protect Development",
+	"image": "ludeeus/container:integration",
+	"context": "..",
+	"appPort": [
+		"5000:5000",
+		"9123:8123"
+	],
+	"runArgs": [
+		"-v",
+		"${env:HOME}${env:USERPROFILE}/.ssh:/tmp/.ssh" // This is added so you can push from inside the container
+	],
+	"extensions": [
+		"ms-python.python",
+		"github.vscode-pull-request-github",
+		"tabnine.tabnine-vscode"
+	],
+	"settings": {
+		"files.eol": "\n",
+		"editor.tabSize": 4,
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/usr/bin/python3",
+		"python.linting.pylintEnabled": true,
+		"python.linting.enabled": true,
+		"python.formatting.provider": "black",
+		"editor.formatOnPaste": false,
+		"editor.formatOnSave": true,
+		"editor.formatOnType": true,
+		"files.trimTrailingWhitespace": true,
+		"yaml.customTags": [
+			"!secret scalar"
+		]
+	}
+}


### PR DESCRIPTION
Contains a fix for the issue I mentioned in #21 to handle that the authentication token has expired, in which case it will automatically authenticate again. Please test if everything still works on CloudKey+

Btw I also added .devcontainer back from my last PR. You may not be familiar with this feature but it makes it very easy to get a separate python dev environment and a separate instance of home assistance running docker for development in Visual Studio Code.
I am using it for all my small HA contributions. It is a cool technology and very easy to use.
More info here: https://code.visualstudio.com/docs/remote/containers
Basically just install docker on you dev machine and use Visual Studio Code and the VSCode extension. And btw the Home Assistant repo itself also has a .devcontainer defined.
 
You could consider adding something like as the last thing to the readme:

## Contribute to project and developing with a [devcontainer](https://code.visualstudio.com/docs/remote/containers)

1. Fork and clone the repository.
2. Open in VSCode and choose to open in devcontainer. Must have [VSCode devcontainer prerequisites](https://code.visualstudio.com/docs/remote/containers#_getting-started).
3. Create a secrets.yaml file in .devcontainer/secrets.yaml with content

   ```yaml
   unifiprotect_host: 192.168.1.1 # Your protect address
   unifiprotect_port: 443  # The port. Typically 7443 for CloudKey+ or 443 for UnifiOS
   unifiprotect_user: YOUR_USERNAME
   unifiprotect_password: YOUR_PASSWORD

   ```

4. Run the command `container start` from VSCode terminal
5. A fresh Home Assistant test instance will install and will eventually be running on port `9123` with this integration running
