### PR TITLE
DevContainer: Enable debugger 

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,6 +1,9 @@
 default_config:
 cloud:
 
+ptvsd:
+  wait: False # Set to True if you want hass to break and wait for debugger to attach
+
 stream:
 
 unifiprotect:

--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,5 +1,4 @@
 default_config:
-cloud:
 
 ptvsd:
   wait: False # Set to True if you want hass to break and wait for debugger to attach

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
 	"extensions": [
 		"ms-python.python",
 		"github.vscode-pull-request-github",
-		"tabnine.tabnine-vscode"
+		"tabnine.tabnine-vscode",
+		"eamodio.gitlens"
 	],
 	"settings": {
 		"files.eol": "\n",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,9 @@
 	"image": "ludeeus/container:integration",
 	"context": "..",
 	"appPort": [
-		"5000:5000",
 		"9123:8123"
 	],
+	"postCreateCommand": "container install",
 	"runArgs": [
 		"-v",
 		"${env:HOME}${env:USERPROFILE}/.ssh:/tmp/.ssh" // This is added so you can push from inside the container

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Debug Unifi Protect",
+            "type": "python",
+            "request": "attach",
+            "justMyCode": false,
+            "port": 5678,
+            "host": "localhost",
+            "pathMappings": [
+                {
+                    "localRoot": "/workspaces/unifiprotect",
+                    "remoteRoot": "."
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Hi Bjarne,

Just a small PR to improve the .devcontainer setup so that the debugger in VS Code works to debug the integration.

Also note that when you use create the devcontainer it pulls the latests version of the Home Assistant dev branch. And I get some error right now during init as the dev branch seems to some error currently.
In the VS code shell you can type "container set-version" to chose which Home Assistant version is used e.g. 0.109.4
Also if you type just "container" it will list the commands available.