### PR TITLE
Fix missing lastRing data with get()

### DIFF
--- a/custom_components/unifiprotect/unifi_protect_server.py
+++ b/custom_components/unifiprotect/unifi_protect_server.py
@@ -187,7 +187,7 @@ class UpvServer:
                     # Get the last time doorbell was ringing
                     lastring = (
                         None
-                        if camera["lastRing"] is None
+                        if camera.get("lastRing") is None
                         else datetime.datetime.fromtimestamp(
                             int(camera["lastRing"]) / 1000
                         ).strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
Use camera.get("lastRing") instead of camera["lastRing"] to work around cases where the camera object does not have a "lastRing" member. get() will return None if "lastRing" is not present.

This resolves https://github.com/briis/unifiprotect/issues/54