### PR TITLE
Force a camera update when changing the switch

### DIFF
--- a/custom_components/unifiprotect/data.py
+++ b/custom_components/unifiprotect/data.py
@@ -39,11 +39,16 @@ class UnifiProtectData:
         if self._unsub_interval:
             self._unsub_interval()
             self._unsub_interval = None
+        await self._protectserver.async_disconnect_ws()
 
-    async def async_refresh(self, *_):
+    async def async_refresh(self, *_, force_camera_update=False):
         """Update the data."""
         try:
-            self._async_process_updates(await self._protectserver.update())
+            self._async_process_updates(
+                await self._protectserver.update(
+                    force_camera_update=force_camera_update
+                )
+            )
             self.last_update_success = True
         except NvrError:
             if self.last_update_success:

--- a/custom_components/unifiprotect/switch.py
+++ b/custom_components/unifiprotect/switch.py
@@ -139,7 +139,7 @@ class UnifiProtectSwitch(UnifiProtectEntity, SwitchDevice):
         else:
             _LOGGER.debug("Changing Status Light to On")
             await self.upv.set_camera_status_light(self._camera_id, True)
-        await self.protect_data.async_refresh()
+        await self.protect_data.async_refresh(force_camera_update=True)
 
     async def async_turn_off(self, **kwargs):
         """Turn the device off."""
@@ -152,4 +152,4 @@ class UnifiProtectSwitch(UnifiProtectEntity, SwitchDevice):
         else:
             _LOGGER.debug("Turning off Recording")
             await self.upv.set_camera_recording(self._camera_id, TYPE_RECORD_NEVER)
-        await self.protect_data.async_refresh()
+        await self.protect_data.async_refresh(force_camera_update=True)


### PR DESCRIPTION
Force a camera update when changing the switch so it updates right away.

Disconnect websocket when the integration is unloaded.

Requires https://github.com/briis/pyunifiprotect/pull/7