### PR TITLE
Add a retry if the first update request fails

### DIFF
--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -86,6 +86,8 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         raise ConfigEntryNotReady from notreadyerror
 
     await protect_data.async_setup()
+    if not protect_data.last_update_success:
+        raise ConfigEntryNotReady
 
     update_listener = entry.add_update_listener(_async_options_updated)
 


### PR DESCRIPTION
We would continue on if the first bootstrap call failed which could lead to partial setup. Usually the 500 error is transient so throwing `ConfigEntryNotReady` will cause the config entry to try again later.

Fixes #181

