### PR TITLE
Return False when auth fails

### DIFF
--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -82,7 +82,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         _LOGGER.error(
             "Could not Authorize against Unifi Protect. Please reinstall the Integration."
         )
-        return
+        return False
     except (NvrError, ServerDisconnectedError) as notreadyerror:
         raise ConfigEntryNotReady from notreadyerror
 


### PR DESCRIPTION
Fixes error when auth failes `2021-04-09 03:16:36 ERROR (MainThread) [homeassistant.config_entries] unifiprotect.async_setup_entry did not return boolean`