### PR TITLE
0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # // Changelog
 
+## 0.9.0 Beta 1
+
+Released: July 6th, 2021
+
+* `NEW`: This release adds support for the UFP Viewport device. This is done by adding a the `media_player` platform, from where the views defined in Unifi Protect can be selected as source. When selecting the source, the Viewport will change it's current view to the selected source. The `media_player` platform will only be setup if UFP Viewports are found in Unfi Protect.
+* `NEW`: As part of the support for the UFP Viewport, there also a new service being created, called `unifiprotect.set_viewport_view`. This service requires two parameters: The `entity_id` of the Viewport and the `view_id` of the View you want to set. `view_id` is a long string, but you can find the id number when looking at the Attributes for the media_player.
+
 ## 0.8.9
 
 Released: June 29th, 2021

--- a/custom_components/unifiprotect/binary_sensor.py
+++ b/custom_components/unifiprotect/binary_sensor.py
@@ -19,6 +19,7 @@ from .const import (
     DEFAULT_ATTRIBUTION,
     DEVICE_TYPE_DOORBELL,
     DEVICE_TYPE_MOTION,
+    DEVICES_WITH_CAMERA,
     DOMAIN,
 )
 from .entity import UnifiProtectEntity
@@ -61,17 +62,18 @@ async def async_setup_entry(
                 device_data["name"],
             )
 
-        sensors.append(
-            UnifiProtectBinarySensor(
-                upv_object,
-                protect_data,
-                server_info,
-                device_id,
-                DEVICE_TYPE_MOTION,
-                hass,
+        if device_data["type"] in DEVICES_WITH_CAMERA:
+            sensors.append(
+                UnifiProtectBinarySensor(
+                    upv_object,
+                    protect_data,
+                    server_info,
+                    device_id,
+                    DEVICE_TYPE_MOTION,
+                    hass,
+                )
             )
-        )
-        _LOGGER.debug("UNIFIPROTECT MOTION SENSOR CREATED: %s", device_data["name"])
+            _LOGGER.debug("UNIFIPROTECT MOTION SENSOR CREATED: %s", device_data["name"])
 
     async_add_entities(sensors)
 

--- a/custom_components/unifiprotect/const.py
+++ b/custom_components/unifiprotect/const.py
@@ -1,5 +1,6 @@
 """Constant definitions for Unifi Protect Integration."""
 
+# from typing_extensions import Required
 from homeassistant.const import ATTR_ENTITY_ID, CONF_FILENAME
 from homeassistant.helpers import config_validation as cv
 import voluptuous as vol
@@ -20,6 +21,8 @@ ATTR_MIC_SENSITIVITY = "mic_sensitivity"
 ATTR_ONLINE = "online"
 ATTR_PRIVACY_MODE = "privacy_mode"
 ATTR_UP_SINCE = "up_since"
+ATTR_VIEWPORT_ID = "viewport_id"
+ATTR_VIEW_ID = "view_id"
 ATTR_WDR_VALUE = "wdr_value"
 ATTR_ZOOM_POSITION = "zoom_position"
 
@@ -57,6 +60,7 @@ DEVICE_TYPE_LIGHT = "light"
 
 DEVICE_TYPE_DOORBELL = "doorbell"
 DEVICE_TYPE_MOTION = "motion"
+DEVICE_TYPE_VIEWPORT = "viewer"
 
 DEVICES_WITH_CAMERA = (DEVICE_TYPE_CAMERA, DEVICE_TYPE_DOORBELL)
 
@@ -73,6 +77,7 @@ SERVICE_SET_PRIVACY_MODE = "set_privacy_mode"
 SERVICE_SET_ZOOM_POSITION = "set_zoom_position"
 SERVICE_SET_WDR_VALUE = "set_wdr_value"
 SERVICE_SET_DOORBELL_CHIME_DURAION = "set_doorbell_chime_duration"
+SERVICE_SET_VIEWPORT_VIEW = "set_viewport_view"
 
 TYPE_RECORD_MOTION = "motion"
 TYPE_RECORD_ALWAYS = "always"
@@ -104,6 +109,7 @@ UNIFI_PROTECT_PLATFORMS = [
     "sensor",
     "switch",
     "light",
+    "media_player",
 ]
 
 VALID_IR_MODES = [TYPE_IR_ON, TYPE_IR_AUTO, TYPE_IR_OFF, TYPE_IR_LED_OFF]
@@ -216,5 +222,12 @@ SET_DOORBELL_CHIME_DURATION_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Required(CONF_CHIME_DURATION, default=300): vol.Coerce(int),
+    }
+)
+
+SET_VIEW_PORT_VIEW_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.string,
+        vol.Required(ATTR_VIEW_ID): cv.string,
     }
 )

--- a/custom_components/unifiprotect/manifest.json
+++ b/custom_components/unifiprotect/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/briis/unifiprotect/issues",
   "config_flow": true,
   "requirements": [
-    "pyunifiprotect==0.31.0"
+    "pyunifiprotect==0.31.7"
   ],
   "dependencies": [],
   "version": "0.9.0",

--- a/custom_components/unifiprotect/manifest.json
+++ b/custom_components/unifiprotect/manifest.json
@@ -5,10 +5,10 @@
   "issue_tracker": "https://github.com/briis/unifiprotect/issues",
   "config_flow": true,
   "requirements": [
-    "pyunifiprotect==0.30.20"
+    "pyunifiprotect==0.31.0"
   ],
   "dependencies": [],
-  "version": "0.8.9",
+  "version": "0.9.0",
   "codeowners": [
     "@briis"
   ],

--- a/custom_components/unifiprotect/media_player.py
+++ b/custom_components/unifiprotect/media_player.py
@@ -1,0 +1,170 @@
+"""Provides support for the Viewport Device, using Media Player."""
+import logging
+
+from homeassistant.components.media_player import MediaPlayerEntity
+from homeassistant.components.media_player.const import (
+    SUPPORT_PLAY_MEDIA,
+    SUPPORT_SELECT_SOURCE,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    STATE_OFF,
+    STATE_PLAYING,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_platform
+
+from .const import (
+    ATTR_DEVICE_MODEL,
+    DEFAULT_ATTRIBUTION,
+    DEVICE_TYPE_VIEWPORT,
+    DOMAIN,
+    SERVICE_SET_VIEWPORT_VIEW,
+    SET_VIEW_PORT_VIEW_SCHEMA,
+)
+from .entity import UnifiProtectEntity
+
+SUPPORT_VIEWPORT = SUPPORT_SELECT_SOURCE | SUPPORT_PLAY_MEDIA
+ATTR_VIEWS = "views"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up Viewport Media Players for UniFi Protect integration."""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    upv_object = entry_data["upv"]
+    protect_data = entry_data["protect_data"]
+    server_info = entry_data["server_info"]
+    if not protect_data.data:
+        return
+
+    # Get Current Views
+    liveviews = await upv_object.get_live_views()
+
+    viewports = []
+    for device_id in protect_data.data:
+        device_data = protect_data.data[device_id]
+        if device_data["type"] == DEVICE_TYPE_VIEWPORT:
+            viewports.append(
+                UnifiProtectMediaPlayer(
+                    upv_object,
+                    protect_data,
+                    server_info,
+                    device_id,
+                    DEVICE_TYPE_VIEWPORT,
+                    liveviews,
+                )
+            )
+            _LOGGER.debug(
+                "UNIFIPROTECT VIEWPORT PLAYER CREATED: %s",
+                device_data["name"],
+            )
+
+    if not viewports:
+        return
+
+    platform = entity_platform.current_platform.get()
+    platform.async_register_entity_service(
+        SERVICE_SET_VIEWPORT_VIEW, SET_VIEW_PORT_VIEW_SCHEMA, "async_set_viewport_view"
+    )
+
+    async_add_entities(viewports)
+
+    return True
+
+
+class UnifiProtectMediaPlayer(UnifiProtectEntity, MediaPlayerEntity):
+    """A Unifi Protect Viewport Media Player."""
+
+    def __init__(
+        self,
+        upv_object,
+        protect_data,
+        server_info,
+        device_id,
+        sensor_type,
+        liveviews,
+    ):
+        """Initialize the Viewport Media Player."""
+        super().__init__(upv_object, protect_data, server_info, device_id, None)
+        self._name = f"{sensor_type.capitalize()} {self._device_data['name']}"
+        self._liveviews = liveviews
+
+    @property
+    def name(self):
+        """Return name of the sensor."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return Off if Viewport is Off, else Playing."""
+        if self._device_data["online"]:
+            return STATE_PLAYING
+        return STATE_OFF
+
+    @property
+    def icon(self):
+        """Sets the icon for this device."""
+        return "mdi:monitor-dashboard"
+
+    @property
+    def source(self):
+        """Name of the current liveview source."""
+        return self.get_view_name_from_id(self._device_data["liveview"])
+
+    @property
+    def source_list(self):
+        """List of available liveview sources."""
+        _sources = []
+        for item in self._liveviews:
+            _sources.append(item["name"])
+        return _sources
+
+    @property
+    def supported_features(self):
+        """Flag media player features that are supported."""
+        return SUPPORT_VIEWPORT
+
+    @property
+    def media_title(self):
+        """Title of current playing media."""
+        return self.get_view_name_from_id(self._device_data["liveview"])
+
+    @property
+    def device_state_attributes(self):
+        """Return the device state attributes."""
+        return {
+            ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION,
+            ATTR_DEVICE_MODEL: self._model,
+            ATTR_VIEWS: self._liveviews,
+        }
+
+    def get_view_name_from_id(self, view_id):
+        """Returns the Liveview Name from the ID"""
+        _source = None
+        for item in self._liveviews:
+            if view_id == item["id"]:
+                _source = item["name"]
+                break
+        return _source
+
+    async def async_select_source(self, source):
+        """Set the Liveview."""
+        self._liveviews = await self.upv_object.get_live_views()
+        view_id = None
+        for item in self._liveviews:
+            if item["name"] == source:
+                view_id = item["id"]
+                break
+
+        if view_id is not None:
+            await self.async_set_viewport_view(view_id)
+
+    async def async_set_viewport_view(self, view_id):
+        """Change Liveview on Viewport."""
+
+        await self.upv_object.set_viewport_view(self._device_id, view_id)

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -348,3 +348,22 @@ set_doorbell_chime_duration:
           max: 10000
           step: 100
           mode: slider
+set_viewport_view:
+  name: Set Viewport View
+  description: "Change the Liveview on the specified Viewport Device"
+  fields:
+    entity_id:
+      name: Viewport ID
+      description: The ID number of the Viewport where the view will be displayed
+      example: "60e2c6a300ed6f038700248f"
+      required: true
+      selector:
+        entity:
+          integration: unifiprotect
+          domain: media_player
+    view_id:
+      name: Liveview ID
+      description: The ID number of the view to be displayed on the Viewport
+      required: true
+      selector:
+        string:

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -366,4 +366,5 @@ set_viewport_view:
       description: The ID number of the view to be displayed on the Viewport
       required: true
       selector:
-        string:
+        text:
+      example: 602631ab021688038700232b

--- a/custom_components/unifiprotect/switch.py
+++ b/custom_components/unifiprotect/switch.py
@@ -39,7 +39,7 @@ SWITCH_TYPES = {
     "record_always": ["Record Always", "video", "record_always", "recording_mode"],
     "record_smart": ["Record Smart", "video", "record_smart", "has_smartdetect"],
     "ir_mode": ["IR Active", "brightness-4", "ir_mode", "ir_mode"],
-    "status_light": ["Status Light On", "led-on", "status_light", None],
+    "status_light": ["Status Light On", "led-on", "status_light", "has_ledstatus"],
     "hdr_mode": ["HDR Mode", "brightness-7", "hdr_mode", "has_hdr"],
     "high_fps": ["High FPS", "video-high-definition", "high_fps", "has_highfps"],
     "light_motion": [


### PR DESCRIPTION
* `NEW`: This release adds support for the UFP Viewport device. This is done by adding a the `media_player` platform, from where the views defined in Unifi Protect can be selected as source. When selecting the source, the Viewport will change it's current view to the selected source. The `media_player` platform will only be setup if UFP Viewports are found in Unfi Protect.
* `NEW`: As part of the support for the UFP Viewport, there also a new service being created, called `unifiprotect.set_viewport_view`. This service requires two parameters: The `entity_id` of the Viewport and the `view_id` of the View you want to set. `view_id` is a long string, but you can find the id number when looking at the Attributes for the media_player.