### PR TITLE
Fixing Standard Issue

### DIFF
--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -20,7 +20,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.device_registry as dr
-from homeassistant.helpers.typing import ConfigType
 from pyunifiprotect import NotAuthorized, NvrError, UpvServer
 from pyunifiprotect.const import SERVER_ID
 

--- a/custom_components/unifiprotect/config_flow.py
+++ b/custom_components/unifiprotect/config_flow.py
@@ -92,17 +92,13 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_PORT: user_input[CONF_PORT],
                 CONF_USERNAME: user_input.get(CONF_USERNAME),
                 CONF_PASSWORD: user_input.get(CONF_PASSWORD),
-                CONF_DISABLE_RTSP: user_input.get(CONF_DISABLE_RTSP),
-                CONF_DOORBELL_TEXT: user_input.get(CONF_DOORBELL_TEXT),
-                CONF_SNAPSHOT_DIRECT: user_input.get(CONF_SNAPSHOT_DIRECT),
-                CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
             },
             options={
                 CONF_USERNAME: user_input.get(CONF_USERNAME),
                 CONF_PASSWORD: user_input.get(CONF_PASSWORD),
-                CONF_DISABLE_RTSP: user_input.get(CONF_DISABLE_RTSP),
-                CONF_DOORBELL_TEXT: user_input.get(CONF_DOORBELL_TEXT),
-                CONF_SNAPSHOT_DIRECT: user_input.get(CONF_SNAPSHOT_DIRECT),
+                CONF_DISABLE_RTSP: False,
+                CONF_DOORBELL_TEXT: "",
+                CONF_SNAPSHOT_DIRECT: False,
             },
         )
 
@@ -116,9 +112,6 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
                     vol.Required(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
-                    vol.Optional(CONF_DISABLE_RTSP, default=False): bool,
-                    vol.Optional(CONF_DOORBELL_TEXT): str,
-                    vol.Optional(CONF_SNAPSHOT_DIRECT, default=False): bool,
                 }
             ),
             errors=errors or {},

--- a/custom_components/unifiprotect/data.py
+++ b/custom_components/unifiprotect/data.py
@@ -31,7 +31,7 @@ class UnifiProtectData:
         )
         await self.async_refresh()
 
-    async def async_stop(self):
+    async def async_stop(self, *args):
         """Stop processing data."""
         if self._unsub_websocket:
             self._unsub_websocket()

--- a/custom_components/unifiprotect/manifest.json
+++ b/custom_components/unifiprotect/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/briis/unifiprotect/issues",
   "config_flow": true,
   "requirements": [
-    "pyunifiprotect==0.35.8"
+    "pyunifiprotect==1.0.1"
   ],
   "dependencies": [],
   "version": "0.10.0",

--- a/custom_components/unifiprotect/strings.json
+++ b/custom_components/unifiprotect/strings.json
@@ -8,10 +8,7 @@
                     "host": "IP Address of Unifi Protect Server",
                     "port": "Port Number: (7443 NON UnifiOS, 443 UnifiOS)",
                     "username": "Username",
-                    "password": "Password",
-                    "disable_rtsp": "Disable the RTSP stream",
-                    "doorbell_text": "Add a comma separated list of Custom Texts for the doorbell. Leave blank if no Doorbel",
-                    "snapshot_direct": "Use Anonymous Snapshots (Must be enabled on all Cameras)"
+                    "password": "Password"
                 }
             }
         },

--- a/custom_components/unifiprotect/translations/da.json
+++ b/custom_components/unifiprotect/translations/da.json
@@ -16,10 +16,7 @@
                     "host": "IP adresse på Unifi Protect Server",
                     "port": "Port nummer (7443 NON UnifiOS, 443 UnifiOS)",
                     "username": "Brugernavn",
-                    "password": "Kodeord",
-                    "disable_rtsp": "Deaktiver RTSP-signalet",
-                    "doorbell_text": "Komma separaret liste af tekst der kan vises på Dørklokken. Efterlad tom hvis ingen dørklokke.",
-                    "snapshot_direct": "Brug anonyme snapshots (Skal være aktiveret på alle kameraer)"
+                    "password": "Kodeord"
                 }
             }
         }

--- a/custom_components/unifiprotect/translations/de.json
+++ b/custom_components/unifiprotect/translations/de.json
@@ -16,10 +16,7 @@
                     "host": "IP-Adresse des Unifi Protect Server",
                     "port": "Portnummer (7443 NON UnifiOS, 443 UnifiOS)",
                     "username": "Username",
-                    "password": "Password",
-                    "disable_rtsp": "Den RTSP-stream deaktivieren",
-                    "doorbell_text": "Add a comma separated list of Custom Texts for the doorbell. Leave blank if no Doorbel",
-                    "snapshot_direct": "Nutze anonyme Snapshots (Muss für alle Kameras eingestellt sein)"
+                    "password": "Password"
                 }
             }
         }

--- a/custom_components/unifiprotect/translations/en.json
+++ b/custom_components/unifiprotect/translations/en.json
@@ -16,10 +16,7 @@
                     "host": "IP Address of Unifi Protect Server",
                     "port": "Port Number (7443 NON UnifiOS, 443 UnifiOS)",
                     "username": "Username",
-                    "password": "Password",
-                    "disable_rtsp": "Disable the RTSP stream",
-                    "doorbell_text": "Add a comma separated list of Custom Texts for the doorbell. Leave blank if no Doorbel",
-                    "snapshot_direct": "Use Anonymous Snapshots (Must be enabled on all Cameras)"
+                    "password": "Password"
                 }
             }
         }

--- a/custom_components/unifiprotect/translations/fr.json
+++ b/custom_components/unifiprotect/translations/fr.json
@@ -16,10 +16,7 @@
                     "host": "Adresse IP de la Unifi Protect Server",
                     "port": "Numéro de port (7443 NON UnifiOS, 443 UnifiOS)",
                     "username": "Identifiant",
-                    "password": "Mot de passe",
-                    "disable_rtsp": "Désactiver le flux RTSP",
-                    "doorbell_text": "Add a comma separated list of Custom Texts for the doorbell. Leave blank if no Doorbel",
-                    "snapshot_direct": "Utiliser des clichés anonymes (doit être activé sur toutes les caméras)"
+                    "password": "Mot de passe"
                 }
             }
         }

--- a/custom_components/unifiprotect/translations/nb.json
+++ b/custom_components/unifiprotect/translations/nb.json
@@ -16,10 +16,7 @@
                     "host": "IP-adresse til Unifi Protect Server",
                     "port": "Portnummer (7443 NON UnifiOS, 443 UnifiOS)",
                     "username": "Brukenavn",
-                    "password": "Passord",
-                    "disable_rtsp": "Deaktiver RTSP-signalet",
-                    "doorbell_text": "Add a comma separated list of Custom Texts for the doorbell. Leave blank if no Doorbel",
-                    "snapshot_direct": "Bruk anonyme øyeblikksbilder (må være aktivert på alle kameraer)"
+                    "password": "Passord"
                 }
             }
         }

--- a/custom_components/unifiprotect/translations/nl.json
+++ b/custom_components/unifiprotect/translations/nl.json
@@ -16,10 +16,7 @@
                     "host": "IP-Adres van de Unifi Protect Server",
                     "port": "Poort Nummer (7443 voor niet UnifiOS, 443 voor UnifiOS)",
                     "username": "Gebruikersnaam",
-                    "password": "Wachtwoord",
-                    "disable_rtsp": "Schakel de RTSP-stream uit",
-                    "doorbell_text": "Add a comma separated list of Custom Texts for the doorbell. Leave blank if no Doorbel",
-                    "snapshot_direct": "Gebruik anonieme snapshots (moet op alle camera's worden ingeschakeld)"
+                    "password": "Wachtwoord"
                 }
             }
         }


### PR DESCRIPTION
I ran through your suggestions Nick, and have modified `config_flow.py` and `__init__.py` according to your suggestions. It does work, but I am getting an error when I run the STOP command from the Server Management page, and I am not sure why that happens. Here is the log:

```log
2021-11-08 07:06:53 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback UnifiProtectData.async_stop(<Event homeassistant_stop[L]>)
Traceback (most recent call last):
  File "/usr/local/python/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/python/lib/python3.9/site-packages/homeassistant/core.py", line 835, in _onetime_listener
    self._hass.async_run_job(listener, event)
  File "/usr/local/python/lib/python3.9/site-packages/homeassistant/core.py", line 452, in async_run_job
    return self.async_run_hass_job(HassJob(target), *args)
  File "/usr/local/python/lib/python3.9/site-packages/homeassistant/core.py", line 436, in async_run_hass_job
    return self.async_add_hass_job(hassjob, *args)
  File "/usr/local/python/lib/python3.9/site-packages/homeassistant/core.py", line 363, in async_add_hass_job
    task = self.loop.create_task(hassjob.target(*args))
TypeError: async_stop() takes 1 positional argument but 2 were given
````
