### PR TITLE
Fixes HLS streaming

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -1,7 +1,9 @@
 default_config:
 
 stream:
-  ll_hls: True
+  ll_hls: true
+  part_duration: 0.75
+  segment_duration: 2
 
 debugpy:
   start: false
@@ -10,6 +12,7 @@ http:
   server_port: 9123
 
 logger:
-  default: error
+  default: warning
   logs:
+    pyunifiprotect: debug
     custom_components.unifiprotect: debug

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,12 @@
 			"type": "shell",
 			"command": "container set-version",
 			"problemMatcher": []
+		},
+		{
+			"label": "Install Development Home Assistant Version",
+			"type": "shell",
+			"command": "container install",
+			"problemMatcher": []
 		}
 	]
 }

--- a/custom_components/unifiprotect/camera.py
+++ b/custom_components/unifiprotect/camera.py
@@ -161,6 +161,11 @@ class UnifiProtectCamera(UnifiProtectEntity, Camera):
         self.async_write_ha_state()
 
     @property
+    def supported_features(self):
+        """Return supported features for this camera."""
+        return self._attr_supported_features
+
+    @property
     def motion_detection_enabled(self):
         """Camera Motion Detection Status."""
         return self._device_data["recording_mode"] and super().available


### PR DESCRIPTION
* Tweaks dev configuration a bit more
* Adds VS Code task to easily install dev version of HA
* Fixes HLS streaming for camera entities

While I was testing stuff for @bdraco, I noticed that I could no longer do streaming with my UFP cameras. After digging into it, it looks like [this refactor](https://github.com/briis/unifiprotect/pull/336/files#diff-c33d3ccf9e61ed4e354cb42e481a9a258c38eb924658d6abe44f8ae0d3432a7cL152-L162) was the cause.

Core uses the [frontend_stream_type](https://github.com/home-assistant/core/blob/dev/homeassistant/components/camera/__init__.py#L423) attribute, which in turn uses the `supported_features` attribute to enable HLS. 