### PR TITLE
Removes references to UnifiOS port configuration

### DIFF
--- a/custom_components/unifiprotect/translations/da.json
+++ b/custom_components/unifiprotect/translations/da.json
@@ -14,7 +14,7 @@
                 "title": "Unifi Protect",
                 "data": {
                     "host": "IP adresse på Unifi Protect Server",
-                    "port": "Port nummer (7443 NON UnifiOS, 443 UnifiOS)",
+                    "port": "Port nummer",
                     "username": "Brugernavn",
                     "password": "Kodeord"
                 }

--- a/custom_components/unifiprotect/translations/de.json
+++ b/custom_components/unifiprotect/translations/de.json
@@ -14,7 +14,7 @@
                 "title": "Unifi Protect",
                 "data": {
                     "host": "IP-Adresse des Unifi Protect Server",
-                    "port": "Portnummer (7443 NON UnifiOS, 443 UnifiOS)",
+                    "port": "Portnummer",
                     "username": "Username",
                     "password": "Password"
                 }

--- a/custom_components/unifiprotect/translations/en.json
+++ b/custom_components/unifiprotect/translations/en.json
@@ -14,7 +14,7 @@
                 "title": "Unifi Protect",
                 "data": {
                     "host": "IP Address of Unifi Protect Server",
-                    "port": "Port Number (7443 NON UnifiOS, 443 UnifiOS)",
+                    "port": "Port Number",
                     "username": "Username",
                     "password": "Password"
                 }

--- a/custom_components/unifiprotect/translations/fr.json
+++ b/custom_components/unifiprotect/translations/fr.json
@@ -14,7 +14,7 @@
                 "title": "Unifi Protect",
                 "data": {
                     "host": "Adresse IP de la Unifi Protect Server",
-                    "port": "Numéro de port (7443 NON UnifiOS, 443 UnifiOS)",
+                    "port": "Numéro de port",
                     "username": "Identifiant",
                     "password": "Mot de passe"
                 }

--- a/custom_components/unifiprotect/translations/nb.json
+++ b/custom_components/unifiprotect/translations/nb.json
@@ -14,7 +14,7 @@
                 "title": "Unifi Protect",
                 "data": {
                     "host": "IP-adresse til Unifi Protect Server",
-                    "port": "Portnummer (7443 NON UnifiOS, 443 UnifiOS)",
+                    "port": "Portnummer",
                     "username": "Brukenavn",
                     "password": "Passord"
                 }

--- a/custom_components/unifiprotect/translations/nl.json
+++ b/custom_components/unifiprotect/translations/nl.json
@@ -14,7 +14,7 @@
                 "title": "Unifi Protect",
                 "data": {
                     "host": "IP-Adres van de Unifi Protect Server",
-                    "port": "Poort Nummer (7443 voor niet UnifiOS, 443 voor UnifiOS)",
+                    "port": "Poort Nummer",
                     "username": "Gebruikersnaam",
                     "password": "Wachtwoord"
                 }


### PR DESCRIPTION
Since UnifiOS is required now, remove references about UnifiOS/Non-UniFiOS devices in port configuration.