### PR TITLE
Refactors config flow and adds reauth

### DIFF
--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -56,7 +56,7 @@ def _async_import_options_from_data_if_missing(hass: HomeAssistant, entry: Confi
         hass.config_entries.async_update_entry(entry, data=data, options=options)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the Unifi Protect config entries."""
     _async_import_options_from_data_if_missing(hass, entry)
 

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -70,7 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     _LOGGER.debug("Connect to Unfi Protect")
-    protect_data = UnifiProtectData(hass, protectserver, SCAN_INTERVAL)
+    protect_data = UnifiProtectData(hass, protectserver, SCAN_INTERVAL, entry)
 
     try:
         nvr_info = await protectserver.server_information()

--- a/custom_components/unifiprotect/config_flow.py
+++ b/custom_components/unifiprotect/config_flow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Any, Dict, Optional, Tuple
 
 from aiohttp import CookieJar
 from homeassistant import config_entries
@@ -14,6 +14,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from pyunifiprotect import NotAuthorized, NvrError, UpvServer
 from pyunifiprotect.const import SERVER_ID, SERVER_NAME
@@ -29,6 +30,17 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+AUTH_SCHEMA = {
+    vol.Required(CONF_USERNAME): str,
+    vol.Required(CONF_PASSWORD): str,
+}
+
+SETUP_SCHEMA = {
+    vol.Required(CONF_HOST): str,
+    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+    **AUTH_SCHEMA,
+}
+
 
 class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Unifi Protect config flow."""
@@ -37,41 +49,44 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
-    async def async_step_reauth(self, user_input=None):
-        """Perform reauth upon an API authentication error."""
-        return await self._init_config_entry(user_input=user_input, reauth=True)
+    @callback
+    async def _async_create_entry(self, title: str, data: Dict[str, Any]):
+        return self.async_create_entry(
+            title=title,
+            data={**data, CONF_ID: title},
+            options={
+                CONF_DISABLE_RTSP: False,
+                CONF_DOORBELL_TEXT: "",
+            },
+        )
 
-    async def async_step_user(self, user_input=None):
-        """Handle a flow initiated by the user."""
-        return await self._init_config_entry(user_input=user_input)
-
-    def _get_form(self, reauth: bool):
-        form = self._show_setup_form
-        if reauth:
-            form = self._show_reauth_form
-
-        return form
-
-    async def _get_protect(self, user_input) -> Optional[UpvServer]:
+    @callback
+    async def _async_get_nvr_data(
+        self,
+        user_input: Dict[str, Any],
+        entry: Optional[config_entries.ConfigEntry] = None,
+    ) -> Tuple[Optional[Dict[str, Any]], Dict[str, str]]:
         session = async_create_clientsession(
             self.hass, cookie_jar=CookieJar(unsafe=True)
         )
 
-        if self.unique_id is not None:
-            entry = await self.async_set_unique_id(self.unique_id)
-            host = entry.data[CONF_HOST]
-            port = entry.data[CONF_PORT]
-        elif CONF_HOST in user_input and CONF_PORT in user_input:
+        if CONF_HOST in user_input:
             host = user_input[CONF_HOST]
-            port = user_input[CONF_PORT]
+            port = user_input.get(CONF_PORT, DEFAULT_PORT)
+        # reauth flow, pull host/port from existing settings
+        elif entry:
+            host = entry.data[CONF_HOST]
+            port = entry.data.get(CONF_PORT, DEFAULT_PORT)
         else:
-            return None
+            return None, {}
 
-        return UpvServer(
+        protect = UpvServer(
             session=session,
             host=host,
             port=port,
@@ -79,92 +94,78 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             password=user_input[CONF_PASSWORD],
         )
 
-    async def _reload_entry(self, unique_id, user_input):
-        entry = await self.async_set_unique_id(unique_id)
-
-        new_data = entry.data.copy()
-        new_data[CONF_USERNAME] = user_input[CONF_USERNAME]
-        new_data[CONF_PASSWORD] = user_input[CONF_PASSWORD]
-
-        self.hass.config_entries.async_update_entry(entry, data=new_data)
-        await self.hass.config_entries.async_reload(entry.entry_id)
-        return self.async_abort(reason="reauth_successful")
-
-    async def _init_config_entry(self, user_input=None, reauth=False):
-        """Common method to initalize config entry"""
-
-        form = self._get_form(reauth)
-        if user_input is None:
-            return await form(user_input)
-
         errors = {}
-        protect = await self._get_protect(user_input)
-
-        if protect is None:
-            return await form(errors)
-
+        nvr_data = None
         try:
-            server_info = await protect.server_information()
-            if server_info["server_version"] < MIN_REQUIRED_PROTECT_V:
+            nvr_data = await protect.server_information()
+            if nvr_data["server_version"] < MIN_REQUIRED_PROTECT_V:
                 _LOGGER.debug("UniFi Protect Version not supported")
                 errors["base"] = "protect_version"
-                return await form(errors)
-
         except NotAuthorized as ex:
             _LOGGER.debug(ex)
             errors["base"] = "connection_error"
-            return await form(errors)
         except NvrError as ex:
             _LOGGER.debug(ex)
             errors["base"] = "nvr_error"
-            return await form(errors)
 
-        unique_id = server_info[SERVER_ID]
-        if reauth:
-            return await self._reload_entry(unique_id, user_input)
+        return nvr_data, errors
 
-        self._abort_if_unique_id_configured()
-        return self.async_create_entry(
-            title=server_info[SERVER_NAME],
-            data={
-                CONF_ID: server_info[SERVER_NAME],
-                CONF_HOST: user_input[CONF_HOST],
-                CONF_PORT: user_input[CONF_PORT],
-                CONF_USERNAME: user_input.get(CONF_USERNAME),
-                CONF_PASSWORD: user_input.get(CONF_PASSWORD),
-            },
-            options={
-                CONF_DISABLE_RTSP: False,
-                CONF_DOORBELL_TEXT: "",
-            },
-        )
+    @callback
+    def _get_config_entry(self) -> Optional[config_entries.ConfigEntry]:
+        if self.unique_id is None:
+            return None
 
-    async def _show_reauth_form(self, errors=None):
-        """Show the setup form to the user."""
+        for entry in self._async_current_entries(include_ignore=True):
+            if entry.unique_id == self.unique_id:
+                return entry
+
+        return None
+
+    async def async_step_reauth(self, user_input: Dict[str, Any] = None) -> FlowResult:
+        """Perform reauth upon an API authentication error."""
+
+        errors = {}
+        if user_input is not None:
+            entry = self._get_config_entry()
+            if not entry:
+                return await self.async_step_user()
+
+            # validate login data
+            nvr_data, errors = await self._async_get_nvr_data(user_input, entry=entry)
+
+            if nvr_data is not None:
+                new_data = {
+                    **entry.data,
+                    CONF_USERNAME: user_input[CONF_USERNAME],
+                    CONF_PASSWORD: user_input[CONF_PASSWORD],
+                }
+                self.hass.config_entries.async_update_entry(entry, data=new_data)
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
+
         return self.async_show_form(
             step_id="reauth",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_USERNAME): str,
-                    vol.Required(CONF_PASSWORD): str,
-                }
-            ),
-            errors=errors or {},
+            data_schema=vol.Schema(AUTH_SCHEMA),
+            errors=errors,
         )
 
-    async def _show_setup_form(self, errors=None):
-        """Show the setup form to the user."""
+    async def async_step_user(self, user_input: Dict[str, Any] = None) -> FlowResult:
+        """Handle a flow initiated by the user."""
+
+        errors = {}
+        if user_input is not None:
+            nvr_data, errors = await self._async_get_nvr_data(user_input)
+
+            if nvr_data is not None:
+                await self.async_set_unique_id(nvr_data[SERVER_ID])
+                self._abort_if_unique_id_configured()
+
+                return await self._async_create_entry(nvr_data[SERVER_NAME], user_input)
+
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_HOST): str,
-                    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-                    vol.Required(CONF_USERNAME): str,
-                    vol.Required(CONF_PASSWORD): str,
-                }
-            ),
-            errors=errors or {},
+            data_schema=vol.Schema(SETUP_SCHEMA),
+            errors=errors,
         )
 
 

--- a/custom_components/unifiprotect/config_flow.py
+++ b/custom_components/unifiprotect/config_flow.py
@@ -111,8 +111,7 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
 
         errors = {}
-        if self.entry is None:
-            return await self.async_step_user()
+        assert self.entry is not None
 
         # prepopulate fields
         form_data = {**self.entry.data}

--- a/custom_components/unifiprotect/config_flow.py
+++ b/custom_components/unifiprotect/config_flow.py
@@ -120,7 +120,7 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             # validate login data
             nvr_data, errors = await self._async_get_nvr_data(form_data)
-            if nvr_data is not None:
+            if not errors:
                 self.hass.config_entries.async_update_entry(self.entry, data=form_data)
                 await self.hass.config_entries.async_reload(self.entry.entry_id)
                 return self.async_abort(reason="reauth_successful")
@@ -147,7 +147,7 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             nvr_data, errors = await self._async_get_nvr_data(user_input)
 
-            if nvr_data is not None:
+            if not errors:
                 await self.async_set_unique_id(nvr_data[SERVER_ID])
                 self._abort_if_unique_id_configured()
 

--- a/custom_components/unifiprotect/config_flow.py
+++ b/custom_components/unifiprotect/config_flow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional, Tuple
+from typing import Any
 
 from aiohttp import CookieJar
 from homeassistant import config_entries
@@ -39,7 +39,7 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.entry: Optional[config_entries.ConfigEntry] = None
+        self.entry: config_entries.ConfigEntry | None = None
 
     @staticmethod
     @callback
@@ -50,7 +50,7 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return OptionsFlowHandler(config_entry)
 
     @callback
-    async def _async_create_entry(self, title: str, data: Dict[str, Any]):
+    async def _async_create_entry(self, title: str, data: dict[str, Any]):
         return self.async_create_entry(
             title=title,
             data={**data, CONF_ID: title},
@@ -63,8 +63,8 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     async def _async_get_nvr_data(
         self,
-        user_input: Dict[str, Any],
-    ) -> Tuple[Optional[Dict[str, Any]], Dict[str, str]]:
+        user_input: dict[str, Any],
+    ) -> tuple[dict[str, Any] | None, dict[str, str]]:
         session = async_create_clientsession(
             self.hass, cookie_jar=CookieJar(unsafe=True)
         )
@@ -100,7 +100,7 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return nvr_data, errors
 
-    async def async_step_reauth(self, user_input: Dict[str, Any]) -> FlowResult:
+    async def async_step_reauth(self, user_input: dict[str, Any]) -> FlowResult:
         """Perform reauth upon an API authentication error."""
 
         self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
@@ -140,7 +140,7 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_user(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a flow initiated by the user."""
 

--- a/custom_components/unifiprotect/config_flow.py
+++ b/custom_components/unifiprotect/config_flow.py
@@ -30,17 +30,6 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-AUTH_SCHEMA = {
-    vol.Required(CONF_USERNAME): str,
-    vol.Required(CONF_PASSWORD): str,
-}
-
-SETUP_SCHEMA = {
-    vol.Required(CONF_HOST): str,
-    vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
-    **AUTH_SCHEMA,
-}
-
 
 class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Unifi Protect config flow."""
@@ -70,7 +59,6 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def _async_get_nvr_data(
         self,
         user_input: Dict[str, Any],
-        entry: Optional[config_entries.ConfigEntry] = None,
     ) -> Tuple[Optional[Dict[str, Any]], Dict[str, str]]:
         session = async_create_clientsession(
             self.hass, cookie_jar=CookieJar(unsafe=True)
@@ -79,10 +67,6 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if CONF_HOST in user_input:
             host = user_input[CONF_HOST]
             port = user_input.get(CONF_PORT, DEFAULT_PORT)
-        # reauth flow, pull host/port from existing settings
-        elif entry:
-            host = entry.data[CONF_HOST]
-            port = entry.data.get(CONF_PORT, DEFAULT_PORT)
         else:
             return None, {}
 
@@ -98,54 +82,50 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         nvr_data = None
         try:
             nvr_data = await protect.server_information()
-            if nvr_data["server_version"] < MIN_REQUIRED_PROTECT_V:
-                _LOGGER.debug("UniFi Protect Version not supported")
-                errors["base"] = "protect_version"
         except NotAuthorized as ex:
             _LOGGER.debug(ex)
-            errors["base"] = "connection_error"
+            errors[CONF_PASSWORD] = "invalid_auth"
         except NvrError as ex:
             _LOGGER.debug(ex)
             errors["base"] = "nvr_error"
+        else:
+            if nvr_data["server_version"] < MIN_REQUIRED_PROTECT_V:
+                _LOGGER.debug("UniFi Protect Version not supported")
+                errors["base"] = "protect_version"
 
         return nvr_data, errors
-
-    @callback
-    def _get_config_entry(self) -> Optional[config_entries.ConfigEntry]:
-        if self.unique_id is None:
-            return None
-
-        for entry in self._async_current_entries(include_ignore=True):
-            if entry.unique_id == self.unique_id:
-                return entry
-
-        return None
 
     async def async_step_reauth(self, user_input: Dict[str, Any] = None) -> FlowResult:
         """Perform reauth upon an API authentication error."""
 
         errors = {}
+
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if entry is None:
+            return await self.async_step_user()
+
+        # prepopulate fields
+        form_data = {**entry.data}
         if user_input is not None:
-            entry = self._get_config_entry()
-            if not entry:
-                return await self.async_step_user()
+            form_data.update(user_input)
 
             # validate login data
-            nvr_data, errors = await self._async_get_nvr_data(user_input, entry=entry)
-
+            nvr_data, errors = await self._async_get_nvr_data(form_data)
             if nvr_data is not None:
-                new_data = {
-                    **entry.data,
-                    CONF_USERNAME: user_input[CONF_USERNAME],
-                    CONF_PASSWORD: user_input[CONF_PASSWORD],
-                }
-                self.hass.config_entries.async_update_entry(entry, data=new_data)
+                self.hass.config_entries.async_update_entry(entry, data=form_data)
                 await self.hass.config_entries.async_reload(entry.entry_id)
                 return self.async_abort(reason="reauth_successful")
 
         return self.async_show_form(
             step_id="reauth",
-            data_schema=vol.Schema(AUTH_SCHEMA),
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USERNAME, default=form_data.get(CONF_USERNAME)
+                    ): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
             errors=errors,
         )
 
@@ -162,9 +142,21 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
                 return await self._async_create_entry(nvr_data[SERVER_NAME], user_input)
 
+        user_input = user_input or {}
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(SETUP_SCHEMA),
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=user_input.get(CONF_HOST)): str,
+                    vol.Required(
+                        CONF_PORT, default=user_input.get(CONF_PORT, DEFAULT_PORT)
+                    ): int,
+                    vol.Required(
+                        CONF_USERNAME, default=user_input.get(CONF_USERNAME)
+                    ): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
             errors=errors,
         )
 

--- a/custom_components/unifiprotect/config_flow.py
+++ b/custom_components/unifiprotect/config_flow.py
@@ -34,9 +34,12 @@ _LOGGER = logging.getLogger(__name__)
 class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a Unifi Protect config flow."""
 
-    entry: Optional[config_entries.ConfigEntry] = None
-
     VERSION = 1
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.entry: Optional[config_entries.ConfigEntry] = None
 
     @staticmethod
     @callback
@@ -100,10 +103,12 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(self, user_input: Dict[str, Any]) -> FlowResult:
         """Perform reauth upon an API authentication error."""
 
-        if "entry_id" in self.context:
-            self.entry = self.hass.config_entries.async_get_entry(
-                self.context["entry_id"]
-            )
+        self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
 
         errors = {}
         if self.entry is None:
@@ -122,7 +127,7 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="reauth_successful")
 
         return self.async_show_form(
-            step_id="reauth",
+            step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
                     vol.Required(
@@ -134,7 +139,9 @@ class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_user(self, user_input: Dict[str, Any] = None) -> FlowResult:
+    async def async_step_user(
+        self, user_input: Dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow initiated by the user."""
 
         errors = {}

--- a/custom_components/unifiprotect/strings.json
+++ b/custom_components/unifiprotect/strings.json
@@ -35,7 +35,7 @@
         "step": {
             "init": {
                 "title": "UniFi Protect Options",
-                "description": "Custom Doorbell Texts should be a comma separated list of texts that will usable in a select for your doorbell. These will be in addition to the ones provided by UniFi Protect",
+                "description": "Custom Doorbell Texts should be a comma separated list of texts that will usable in a select for your doorbell. These will be in addition to the ones provided by UniFi Protect. Leave blank if you do not have a doorbell camera.",
                 "data": {
                     "disable_rtsp": "Disable the RTSP stream",
                     "doorbell_text": "Custom Doorbell Texts"

--- a/custom_components/unifiprotect/strings.json
+++ b/custom_components/unifiprotect/strings.json
@@ -1,34 +1,44 @@
 {
     "config": {
-        "step": {
-            "user": {
-                "title": "Unifi Protect",
-                "description": "Set up Unifi Protect to monitor cameras and sensors.",
-                "data": {
-                    "host": "IP Address of Unifi Protect Server",
-                    "port": "Port Number: (7443 NON UnifiOS, 443 UnifiOS)",
-                    "username": "Username",
-                    "password": "Password"
-                }
-            }
+        "abort": {
+            "server_exists": "UniFi Protect Server already configured.",
+            "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
         },
         "error": {
             "connection_error": "Failed to connect. Wrong IP or Username/Password.",
             "protect_version": "UniFi Protect Version is not supported by this Integration",
-            "nvr_error": "Error retrieving data from Unifi Protect."
+            "nvr_error": "Error retrieving data from UniFi Protect."
         },
-        "abort": {
-            "server_exists": "Unifi Protect Server already configured."
+        "step": {
+            "user": {
+                "title": "UniFi Protect Setup",
+                "description": "Set up UniFi Protect to monitor cameras and sensors.",
+                "data": {
+                    "host": "IP Address of UniFi Protect Server",
+                    "port": "Port Number",
+                    "username": "Username",
+                    "password": "Password"
+                }
+            },
+            "reauth": {
+                "title": "UniFi Protect Reauth",
+                "data": {
+                    "host": "IP Address of UniFi Protect Server",
+                    "port": "Port Number",
+                    "username": "Username",
+                    "password": "Password"
+                }
+            }
         }
     },
     "options": {
         "step": {
             "init": {
+                "title": "UniFi Protect Options",
+                "description": "Custom Doorbell Texts should be a comma separated list of texts that will usable in a select for your doorbell. These will be in addition to the ones provided by UniFi Protect",
                 "data": {
-                    "username": "Username",
-                    "password": "Password",
                     "disable_rtsp": "Disable the RTSP stream",
-                    "doorbell_text": "Add a comma separated list of Custom Texts for the doorbell. Leave blank if no Doorbel"
+                    "doorbell_text": "Custom Doorbell Texts"
                 }
             }
         }

--- a/custom_components/unifiprotect/strings.json
+++ b/custom_components/unifiprotect/strings.json
@@ -5,7 +5,7 @@
             "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
         },
         "error": {
-            "connection_error": "Failed to connect. Wrong IP or Username/Password.",
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
             "protect_version": "UniFi Protect Version is not supported by this Integration",
             "nvr_error": "Error retrieving data from UniFi Protect."
         },

--- a/custom_components/unifiprotect/strings.json
+++ b/custom_components/unifiprotect/strings.json
@@ -20,7 +20,7 @@
                     "password": "Password"
                 }
             },
-            "reauth": {
+            "reauth_confirm": {
                 "title": "UniFi Protect Reauth",
                 "data": {
                     "host": "IP Address of UniFi Protect Server",

--- a/custom_components/unifiprotect/translations/da.json
+++ b/custom_components/unifiprotect/translations/da.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "abort": {
-            "server_exists": "Denne Unifi Protect Server er allerede konfigureret."
+            "server_exists": "Denne UniFi Protect Server er allerede konfigureret."
         },
         "error": {
             "connection_error": "Kan ikke forbinde. Forkert IP eller Brugernavn/Kodeord.",
             "protect_version": "UniFi Protect Version er ikke understøttet af denne version.",
-            "nvr_error": "Kan ikke hente data fra Unifi Protect."
+            "nvr_error": "Kan ikke hente data fra UniFi Protect."
         },
         "step": {
             "user": {
-                "description": "Konfigurer Unifi Protect for at monitorere kameraer og sensorer.",
-                "title": "Unifi Protect",
+                "description": "Konfigurer UniFi Protect for at monitorere kameraer og sensorer.",
+                "title": "UniFi Protect",
                 "data": {
-                    "host": "IP adresse på Unifi Protect Server",
+                    "host": "IP adresse på UniFi Protect Server",
                     "port": "Port nummer",
                     "username": "Brugernavn",
                     "password": "Kodeord"

--- a/custom_components/unifiprotect/translations/de.json
+++ b/custom_components/unifiprotect/translations/de.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "abort": {
-            "server_exists": "Unifi Protect Server bereits konfiguriert."
+            "server_exists": "UniFi Protect Server bereits konfiguriert."
         },
         "error": {
             "connection_error": "Verbindung fehlgeschlagen. Falsche IP oder Username/Password.",
             "protect_version": "UniFi Protect Version is not supported by this Integration",
-            "nvr_error": "Fehler beim Datenaustausch mit Unifi Protect."
+            "nvr_error": "Fehler beim Datenaustausch mit UniFi Protect."
         },
         "step": {
             "user": {
-                "description": "Set up Unifi Protect to monitor cameras and sensors.",
-                "title": "Unifi Protect",
+                "description": "Set up UniFi Protect to monitor cameras and sensors.",
+                "title": "UniFi Protect",
                 "data": {
-                    "host": "IP-Adresse des Unifi Protect Server",
+                    "host": "IP-Adresse des UniFi Protect Server",
                     "port": "Portnummer",
                     "username": "Username",
                     "password": "Password"

--- a/custom_components/unifiprotect/translations/en.json
+++ b/custom_components/unifiprotect/translations/en.json
@@ -1,23 +1,33 @@
 {
     "config": {
         "abort": {
-            "server_exists": "Unifi Protect Server already configured."
+            "reauth_successful": "Re-authentication was successful",
+            "server_exists": "UniFi Protect Server already configured."
         },
         "error": {
             "connection_error": "Failed to connect. Wrong IP or Username/Password.",
-            "protect_version": "UniFi Protect Version is not supported by this Integration",
-            "nvr_error": "Error retrieving data from Unifi Protect."
+            "nvr_error": "Error retrieving data from UniFi Protect.",
+            "protect_version": "UniFi Protect Version is not supported by this Integration"
         },
         "step": {
-            "user": {
-                "description": "Set up Unifi Protect to monitor cameras and sensors.",
-                "title": "Unifi Protect",
+            "reauth": {
                 "data": {
-                    "host": "IP Address of Unifi Protect Server",
+                    "host": "IP Address of UniFi Protect Server",
+                    "password": "Password",
                     "port": "Port Number",
-                    "username": "Username",
-                    "password": "Password"
-                }
+                    "username": "Username"
+                },
+                "title": "UniFi Protect Reauth"
+            },
+            "user": {
+                "data": {
+                    "host": "IP Address of UniFi Protect Server",
+                    "password": "Password",
+                    "port": "Port Number",
+                    "username": "Username"
+                },
+                "description": "Set up UniFi Protect to monitor cameras and sensors.",
+                "title": "UniFi Protect Setup"
             }
         }
     },
@@ -25,11 +35,11 @@
         "step": {
             "init": {
                 "data": {
-                    "username": "Username",
-                    "password": "Password",
                     "disable_rtsp": "Disable the RTSP stream",
-                    "doorbell_text": "Add a comma separated list of Custom Texts for the doorbell. Leave blank if no Doorbel"
-                }
+                    "doorbell_text": "Custom Doorbell Texts"
+                },
+                "description": "Custom Doorbell Texts should be a comma separated list of texts that will usable in a select for your doorbell. These will be in addition to the ones provided by UniFi Protect",
+                "title": "UniFi Protect Options"
             }
         }
     }

--- a/custom_components/unifiprotect/translations/en.json
+++ b/custom_components/unifiprotect/translations/en.json
@@ -38,7 +38,7 @@
                     "disable_rtsp": "Disable the RTSP stream",
                     "doorbell_text": "Custom Doorbell Texts"
                 },
-                "description": "Custom Doorbell Texts should be a comma separated list of texts that will usable in a select for your doorbell. These will be in addition to the ones provided by UniFi Protect",
+                "description": "Custom Doorbell Texts should be a comma separated list of texts that will usable in a select for your doorbell. These will be in addition to the ones provided by UniFi Protect. Leave blank if you do not have a doorbell camera.",
                 "title": "UniFi Protect Options"
             }
         }

--- a/custom_components/unifiprotect/translations/en.json
+++ b/custom_components/unifiprotect/translations/en.json
@@ -10,7 +10,7 @@
             "protect_version": "UniFi Protect Version is not supported by this Integration"
         },
         "step": {
-            "reauth": {
+            "reauth_confirm": {
                 "data": {
                     "host": "IP Address of UniFi Protect Server",
                     "password": "Password",

--- a/custom_components/unifiprotect/translations/en.json
+++ b/custom_components/unifiprotect/translations/en.json
@@ -5,7 +5,7 @@
             "server_exists": "UniFi Protect Server already configured."
         },
         "error": {
-            "connection_error": "Failed to connect. Wrong IP or Username/Password.",
+            "invalid_auth": "Invalid authentication",
             "nvr_error": "Error retrieving data from UniFi Protect.",
             "protect_version": "UniFi Protect Version is not supported by this Integration"
         },

--- a/custom_components/unifiprotect/translations/fr.json
+++ b/custom_components/unifiprotect/translations/fr.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "abort": {
-            "server_exists": "Le server Unifi Protect est déjà configuré."
+            "server_exists": "Le server UniFi Protect est déjà configuré."
         },
         "error": {
             "connection_error": "Impossible de se connecter. Mauvaise IP ou identifiant/mot de passe.",
             "protect_version": "UniFi Protect Version is not supported by this Integration",
-            "nvr_error": "Erreur lors de la récupération de données sur Unifi Protect."
+            "nvr_error": "Erreur lors de la récupération de données sur UniFi Protect."
         },
         "step": {
             "user": {
-                "description": "Mettre en place Unifi Protect pour surveiller les caméras et les capteurs.",
-                "title": "Unifi Protect",
+                "description": "Mettre en place UniFi Protect pour surveiller les caméras et les capteurs.",
+                "title": "UniFi Protect",
                 "data": {
-                    "host": "Adresse IP de la Unifi Protect Server",
+                    "host": "Adresse IP de la UniFi Protect Server",
                     "port": "Numéro de port",
                     "username": "Identifiant",
                     "password": "Mot de passe"

--- a/custom_components/unifiprotect/translations/nb.json
+++ b/custom_components/unifiprotect/translations/nb.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "abort": {
-            "server_exists": "Unifi Protect Server er allerede konfigurert."
+            "server_exists": "UniFi Protect Server er allerede konfigurert."
         },
         "error": {
             "connection_error": "Tilkobling mislyktes. Feil IP eller brukernavn / passord.",
             "protect_version": "UniFi Protect Version is not supported by this Integration",
-            "nvr_error": "Feil ved henting av data fra Unifi Protect."
+            "nvr_error": "Feil ved henting av data fra UniFi Protect."
         },
         "step": {
             "user": {
-                "description": "Sett opp Unifi Protect for å overvåke kameraer og sensorer.",
-                "title": "Unifi Protect",
+                "description": "Sett opp UniFi Protect for å overvåke kameraer og sensorer.",
+                "title": "UniFi Protect",
                 "data": {
-                    "host": "IP-adresse til Unifi Protect Server",
+                    "host": "IP-adresse til UniFi Protect Server",
                     "port": "Portnummer",
                     "username": "Brukenavn",
                     "password": "Passord"

--- a/custom_components/unifiprotect/translations/nl.json
+++ b/custom_components/unifiprotect/translations/nl.json
@@ -1,19 +1,19 @@
 {
     "config": {
         "abort": {
-            "server_exists": "Unifi Protect Server is al geconfigureerd."
+            "server_exists": "UniFi Protect Server is al geconfigureerd."
         },
         "error": {
             "connection_error": "Kon niet verbinden. Verkeerd IP of gebruikersnaam/wachtwoord.",
             "protect_version": "UniFi Protect Version is not supported by this Integration",
-            "nvr_error": "Fout bij het ophalen van gegevens vanuit Unifi Protect."
+            "nvr_error": "Fout bij het ophalen van gegevens vanuit UniFi Protect."
         },
         "step": {
             "user": {
-                "description": "Stel Unifi Protect in om cameras and sensoren te gebruiken.",
-                "title": "Unifi Protect",
+                "description": "Stel UniFi Protect in om cameras and sensoren te gebruiken.",
+                "title": "UniFi Protect",
                 "data": {
-                    "host": "IP-Adres van de Unifi Protect Server",
+                    "host": "IP-Adres van de UniFi Protect Server",
                     "port": "Poort Nummer",
                     "username": "Gebruikersnaam",
                     "password": "Wachtwoord"


### PR DESCRIPTION
* Raise `ConfigEntryAuthFailed` on auth failure
* Adds `async_step_reauth` to allow reauth on auth failure
* Refactors `async_step_user` to allow it to be shared between user and reauth steps.
* Updates strings to fix casing of "UniFi"
* Simplifies options flow to only have Disable RTSP and Doorbell Texts