### PR TITLE
Fixes home assistant path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,8 @@ FROM ghcr.io/ludeeus/devcontainer/integration:stable
 
 RUN apt update \
     && sudo apt install -y libpcap-dev ffmpeg vim curl jq libturbojpeg0 \
-    && mkdir -p /workspaces \
-    && cd /workspaces \
+    && mkdir -p /opt \
+    && cd /opt \
     && git clone --depth=1 -b dev https://github.com/home-assistant/core.git hass \
     && python3 -m pip --disable-pip-version-check install --upgrade ./hass \
-    && ln -s /workspaces/unifiprotect/custom_components/unifiprotect /workspaces/hass/homeassistant/components/unifiprotect
+    && ln -s /workspaces/unifiprotect/custom_components/unifiprotect /opt/hass/homeassistant/components/unifiprotect

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,7 +24,7 @@
 			"type": "shell",
 			"command": "echo 'unifiprotect\n' | python3 -m script.translations develop",
 			"options": {
-				"cwd": "/workspaces/hass",
+				"cwd": "/opt/hass",
 			},
 			"problemMatcher": []
 		}


### PR DESCRIPTION
The helper script provided by the base container is "dumb" and cannot handle multiple folders in workspaces. 

* Moves `hass` folder to `/opt` (that is where the other container provided scripts are)
