### PR TITLE
Disables High FPS switch

### DIFF
--- a/custom_components/unifiprotect/switch.py
+++ b/custom_components/unifiprotect/switch.py
@@ -58,14 +58,14 @@ SWITCH_TYPES: tuple[UnifiProtectSwitchEntityDescription, ...] = (
         ufp_required_field="has_hdr",
         ufp_value="hdr_mode",
     ),
-    UnifiProtectSwitchEntityDescription(
-        key=_KEY_HIGH_FPS,
-        name="High FPS",
-        icon="mdi:video-high-definition",
-        entity_category=ENTITY_CATEGORY_CONFIG,
-        ufp_required_field="has_highfps",
-        ufp_value="video_mode",
-    ),
+    # UnifiProtectSwitchEntityDescription(
+    #     key=_KEY_HIGH_FPS,
+    #     name="High FPS",
+    #     icon="mdi:video-high-definition",
+    #     entity_category=ENTITY_CATEGORY_CONFIG,
+    #     ufp_required_field="has_highfps",
+    #     ufp_value="video_mode",
+    # ),
     UnifiProtectSwitchEntityDescription(
         key=_KEY_PRIVACY_MODE,
         name="Privacy Mode",


### PR DESCRIPTION
Temporarily disables High FPS mode switch. We are not doing the proper checks on 0.10 to verify the camera _has_ a High FPS mode before adding the switch. Cameras that do not have one (G3 Flex, G3 Instance, G3 Bullet and G4 Instant) will become bricked and it is quite difficult to fix the issue.

Temporarily fix for https://github.com/briis/unifiprotect/issues/358 until we get 0.11 done.

The PR I have for 0.11 has this issue fixed already as I am using `feature_flags.video_modes` to determine if the camera has a High FPS mode.

Image of High FPS mode switch existing on my G4 Instant: 
![image](https://user-images.githubusercontent.com/490848/143725059-31df37cd-6682-49c0-9f2c-6ef019d8e076.png)

But as you can see, it does not have a high FPS video mode. 
![image](https://user-images.githubusercontent.com/490848/143725094-500975d6-c2d7-4c2f-abd2-2b287c3f7c8d.png)
