### PR TITLE
Replaces all instances of Unifi

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         // Run "Start Home Assistant" task + `debugpy.start` HA service first
         {
-            "name": "Python: Debug Unifi Protect",
+            "name": "Python: Debug UniFi Protect",
             "type": "python",
             "request": "attach",
             "justMyCode": false,

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -1,4 +1,4 @@
-"""Unifi Protect Platform."""
+"""UniFi Protect Platform."""
 from __future__ import annotations
 
 import asyncio
@@ -47,8 +47,8 @@ from .const import (
     SERVICE_REMOVE_DOORBELL_TEXT,
     SERVICE_SET_DEFAULT_DOORBELL_TEXT,
 )
-from .data import UnifiProtectData
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .models import ProtectEntryData
 from .services import (
     add_doorbell_text,
     profile_ws,
@@ -171,7 +171,7 @@ def _async_import_options_from_data_if_missing(
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up the Unifi Protect config entries."""
+    """Set up the UniFi Protect config entries."""
     _async_import_options_from_data_if_missing(hass, entry)
 
     session = async_create_clientsession(hass, cookie_jar=CookieJar(unsafe=True))
@@ -186,7 +186,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ignore_stats=not entry.options.get(CONF_ALL_UPDATES, False),
     )
     _LOGGER.debug("Connect to UniFi Protect")
-    protect_data = UnifiProtectData(hass, protect, SCAN_INTERVAL, entry)
+    protect_data = ProtectData(hass, protect, SCAN_INTERVAL, entry)
 
     try:
         nvr_info = await protect.get_nvr()
@@ -214,7 +214,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not protect_data.last_update_success:
         raise ConfigEntryNotReady
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = UnifiProtectEntryData(
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = ProtectEntryData(
         protect_data=protect_data,
         protect=protect,
         disable_stream=entry.options.get(CONF_DISABLE_RTSP, False),
@@ -266,9 +266,9 @@ async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> Non
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload Unifi Protect config entry."""
+    """Unload UniFi Protect config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+        data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
         await data.protect_data.async_stop()
         hass.data[DOMAIN].pop(entry.entry_id)
     return bool(unload_ok)

--- a/custom_components/unifiprotect/binary_sensor.py
+++ b/custom_components/unifiprotect/binary_sensor.py
@@ -39,9 +39,9 @@ from .const import (
     DOMAIN,
     RING_INTERVAL,
 )
-from .data import UnifiProtectData
-from .entity import AccessTokenMixin, UnifiProtectEntity
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .entity import AccessTokenMixin, ProtectEntity
+from .models import ProtectEntryData
 from .utils import get_nested_attr
 from .views import ThumbnailProxyView
 
@@ -56,7 +56,7 @@ else:
 
 
 @dataclass
-class UnifiprotectRequiredKeysMixin:
+class ProtectRequiredKeysMixin:
     """Mixin for required keys."""
 
     ufp_required_field: str | None
@@ -64,10 +64,10 @@ class UnifiprotectRequiredKeysMixin:
 
 
 @dataclass
-class UnifiProtectBinaryEntityDescription(
-    BinarySensorEntityDescription, UnifiprotectRequiredKeysMixin
+class ProtectBinaryEntityDescription(
+    BinarySensorEntityDescription, ProtectRequiredKeysMixin
 ):
-    """Describes Unifi Protect Binary Sensor entity."""
+    """Describes UniFi Protect Binary Sensor entity."""
 
 
 _KEY_DOORBELL = "doorbell"
@@ -78,15 +78,15 @@ _KEY_BATTERY_LOW = "battery_low"
 _KEY_DISK_HEALTH = "disk_health"
 
 
-SENSE_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
-    UnifiProtectBinaryEntityDescription(
+SENSE_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
+    ProtectBinaryEntityDescription(
         key=_KEY_DOOR,
         name="Door",
         device_class=DEVICE_CLASS_DOOR,
         ufp_required_field=None,
         ufp_value="is_opened",
     ),
-    UnifiProtectBinaryEntityDescription(
+    ProtectBinaryEntityDescription(
         key=_KEY_BATTERY_LOW,
         name="Battery low",
         device_class=DEVICE_CLASS_BATTERY,
@@ -94,7 +94,7 @@ SENSE_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
         ufp_required_field=None,
         ufp_value="battery_status.is_low",
     ),
-    UnifiProtectBinaryEntityDescription(
+    ProtectBinaryEntityDescription(
         key=_KEY_MOTION,
         name="Motion",
         device_class=DEVICE_CLASS_MOTION,
@@ -103,8 +103,8 @@ SENSE_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
     ),
 )
 
-MOTION_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
-    UnifiProtectBinaryEntityDescription(
+MOTION_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
+    ProtectBinaryEntityDescription(
         key=_KEY_MOTION,
         name="Motion",
         device_class=DEVICE_CLASS_MOTION,
@@ -113,8 +113,8 @@ MOTION_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
     ),
 )
 
-CAMERA_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
-    UnifiProtectBinaryEntityDescription(
+CAMERA_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
+    ProtectBinaryEntityDescription(
         key=_KEY_DOORBELL,
         name="Doorbell",
         device_class=DEVICE_CLASS_OCCUPANCY,
@@ -122,7 +122,7 @@ CAMERA_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
         ufp_required_field="feature_flags.has_chime",
         ufp_value="last_ring",
     ),
-    UnifiProtectBinaryEntityDescription(
+    ProtectBinaryEntityDescription(
         key=_KEY_DARK,
         name="Is Dark",
         icon="mdi:brightness-6",
@@ -131,15 +131,15 @@ CAMERA_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
     ),
 )
 
-LIGHT_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
-    UnifiProtectBinaryEntityDescription(
+LIGHT_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
+    ProtectBinaryEntityDescription(
         key=_KEY_DARK,
         name="Is Dark",
         icon="mdi:brightness-6",
         ufp_required_field=None,
         ufp_value="is_dark",
     ),
-    UnifiProtectBinaryEntityDescription(
+    ProtectBinaryEntityDescription(
         key=_KEY_MOTION,
         name="Motion",
         device_class=DEVICE_CLASS_MOTION,
@@ -148,8 +148,8 @@ LIGHT_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
     ),
 )
 
-DISK_SENSORS: tuple[UnifiProtectBinaryEntityDescription, ...] = (
-    UnifiProtectBinaryEntityDescription(
+DISK_SENSORS: tuple[ProtectBinaryEntityDescription, ...] = (
+    ProtectBinaryEntityDescription(
         key=_KEY_DISK_HEALTH,
         name="Disk {index} Health",
         device_class=DEVICE_CLASS_PROBLEM,
@@ -174,8 +174,8 @@ async def async_setup_entry(
     async_add_entities: Callable[[Sequence[Entity]], None],
 ) -> None:
     """Set up binary sensors for UniFi Protect integration."""
-    entry_data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
-    entities: list[UnifiProtectBinarySensor] = _async_device_entities(entry_data)
+    entry_data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+    entities: list[ProtectBinarySensor] = _async_device_entities(entry_data)
     entities += _async_nvr_entities(entry_data)
     entities += _async_motion_entities(hass, entry_data)
 
@@ -185,8 +185,8 @@ async def async_setup_entry(
 @callback
 def _async_motion_entities(
     hass: HomeAssistant,
-    entry_data: UnifiProtectEntryData,
-) -> list[UnifiProtectAccessTokenBinarySensor]:
+    entry_data: ProtectEntryData,
+) -> list[ProtectAccessTokenBinarySensor]:
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
@@ -194,7 +194,7 @@ def _async_motion_entities(
     for device in protect_data.get_by_types({ModelType.CAMERA}):
         for description in MOTION_SENSORS:
             entities.append(
-                UnifiProtectAccessTokenBinarySensor(
+                ProtectAccessTokenBinarySensor(
                     protect, protect_data, device, description
                 )
             )
@@ -209,8 +209,8 @@ def _async_motion_entities(
 
 @callback
 def _async_nvr_entities(
-    entry_data: UnifiProtectEntryData,
-) -> list[UnifiProtectBinarySensor]:
+    entry_data: ProtectEntryData,
+) -> list[ProtectBinarySensor]:
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
@@ -219,7 +219,7 @@ def _async_nvr_entities(
     for index, _ in enumerate(device.system_info.storage.devices):
         for description in DISK_SENSORS:
             entities.append(
-                UnifiProtectBinarySensor(
+                ProtectBinarySensor(
                     protect, protect_data, device, description, index=index
                 )
             )
@@ -233,8 +233,8 @@ def _async_nvr_entities(
 
 @callback
 def _async_device_entities(
-    entry_data: UnifiProtectEntryData,
-) -> list[UnifiProtectBinarySensor]:
+    entry_data: ProtectEntryData,
+) -> list[ProtectBinarySensor]:
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
@@ -257,7 +257,7 @@ def _async_device_entities(
                     continue
 
             entities.append(
-                UnifiProtectBinarySensor(
+                ProtectBinarySensor(
                     protect,
                     protect_data,
                     device,
@@ -273,15 +273,15 @@ def _async_device_entities(
     return entities
 
 
-class UnifiProtectBinarySensor(UnifiProtectEntity, BinarySensorEntity):
-    """A Unifi Protect Binary Sensor."""
+class ProtectBinarySensor(ProtectEntity, BinarySensorEntity):
+    """A UniFi Protect Binary Sensor."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         device: ProtectDeviceModel,
-        description: UnifiProtectBinaryEntityDescription,
+        description: ProtectBinaryEntityDescription,
         index: int | None = None,
     ) -> None:
         """Initialize the Binary Sensor."""
@@ -293,7 +293,7 @@ class UnifiProtectBinarySensor(UnifiProtectEntity, BinarySensorEntity):
 
         assert isinstance(device, (Camera, Light, Sensor, NVR))
         self.device: Camera | Light | Sensor | NVR = device
-        self.entity_description: UnifiProtectBinaryEntityDescription = description
+        self.entity_description: ProtectBinaryEntityDescription = description
         super().__init__(protect, protect_data, device, description)
         name = description.name or ""
         self._attr_name = f"{self.device.name} {name.title()}"
@@ -444,13 +444,13 @@ class UnifiProtectBinarySensor(UnifiProtectEntity, BinarySensorEntity):
         return {**super().extra_state_attributes, **self._extra_state_attributes}
 
 
-class UnifiProtectAccessTokenBinarySensor(UnifiProtectBinarySensor, AccessTokenMixin):
+class ProtectAccessTokenBinarySensor(ProtectBinarySensor, AccessTokenMixin):
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         device: ProtectDeviceModel,
-        description: UnifiProtectBinaryEntityDescription,
+        description: ProtectBinaryEntityDescription,
         index: int | None = None,
     ) -> None:
         assert isinstance(device, Camera)

--- a/custom_components/unifiprotect/button.py
+++ b/custom_components/unifiprotect/button.py
@@ -1,4 +1,4 @@
-"""Support for Ubiquiti's Unifi Protect NVR."""
+"""Support for Ubiquiti's UniFi Protect NVR."""
 from __future__ import annotations
 
 import logging
@@ -12,9 +12,9 @@ from pyunifiprotect import ProtectApiClient
 from pyunifiprotect.data.base import ProtectAdoptableDeviceModel, ProtectDeviceModel
 
 from .const import DEVICES_THAT_ADOPT, DOMAIN
-from .data import UnifiProtectData
-from .entity import UnifiProtectEntity
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .entity import ProtectEntity
+from .models import ProtectEntryData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,13 +25,13 @@ async def async_setup_entry(
     async_add_entities: Callable[[Sequence[Entity]], None],
 ) -> None:
     """Discover devices on a UniFi Protect NVR."""
-    entry_data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+    entry_data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
     async_add_entities(
         [
-            UnifiProtectButton(
+            ProtectButton(
                 protect,
                 protect_data,
                 device,
@@ -41,16 +41,16 @@ async def async_setup_entry(
     )
 
 
-class UnifiProtectButton(UnifiProtectEntity, ButtonEntity):
+class ProtectButton(ProtectEntity, ButtonEntity):
     """A Ubiquiti UniFi Protect Reboot button."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         device: ProtectDeviceModel,
     ):
-        """Initialize an Unifi camera."""
+        """Initialize an UniFi camera."""
         assert isinstance(device, ProtectAdoptableDeviceModel)
         self.device: ProtectAdoptableDeviceModel = device
         super().__init__(protect, protect_data, device, None)

--- a/custom_components/unifiprotect/camera.py
+++ b/custom_components/unifiprotect/camera.py
@@ -1,4 +1,4 @@
-"""Support for Ubiquiti's Unifi Protect NVR."""
+"""Support for Ubiquiti's UniFi Protect NVR."""
 from __future__ import annotations
 
 from datetime import timedelta
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity import Entity
 from pyunifiprotect.api import ProtectApiClient
-from pyunifiprotect.data import Camera as UnifiCamera
+from pyunifiprotect.data import Camera as ProtectCamera
 from pyunifiprotect.data.devices import CameraChannel
 from pyunifiprotect.data.types import (
     DoorbellMessageType,
@@ -61,16 +61,16 @@ from .const import (
     SET_ZOOM_POSITION_SCHEMA,
     TYPE_RECORD_NOTSET,
 )
-from .data import UnifiProtectData
-from .entity import UnifiProtectEntity
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .entity import ProtectEntity
+from .models import ProtectEntryData
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def get_camera_channels(
     protect: ProtectApiClient,
-) -> Generator[tuple[UnifiCamera, CameraChannel, bool], None, None]:
+) -> Generator[tuple[ProtectCamera, CameraChannel, bool], None, None]:
 
     for camera in protect.bootstrap.cameras.values():
         is_default = True
@@ -89,8 +89,8 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: Callable[[Sequence[Entity]], None],
 ) -> None:
-    """Discover cameras on a Unifi Protect NVR."""
-    entry_data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+    """Discover cameras on a UniFi Protect NVR."""
+    entry_data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
     protect = entry_data.protect
     protect_data = entry_data.protect_data
     disable_stream = entry_data.disable_stream
@@ -99,7 +99,7 @@ async def async_setup_entry(
     for camera, channel, is_default in get_camera_channels(protect):
         if channel.is_rtsp_enabled:
             items.append(
-                UnifiProtectCamera(
+                ProtectCamera(
                     protect,
                     protect_data,
                     camera,
@@ -110,7 +110,7 @@ async def async_setup_entry(
                 )
             )
             items.append(
-                UnifiProtectCamera(
+                ProtectCamera(
                     protect,
                     protect_data,
                     camera,
@@ -122,7 +122,7 @@ async def async_setup_entry(
             )
         else:
             items.append(
-                UnifiProtectCamera(
+                ProtectCamera(
                     protect,
                     protect_data,
                     camera,
@@ -190,21 +190,21 @@ async def async_setup_entry(
     )
 
 
-class UnifiProtectCamera(UnifiProtectEntity, Camera):
-    """A Ubiquiti Unifi Protect Camera."""
+class ProtectCamera(ProtectEntity, Camera):
+    """A Ubiquiti UniFi Protect Camera."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
-        camera: UnifiCamera,
+        protect_data: ProtectData,
+        camera: ProtectCamera,
         channel: CameraChannel,
         is_default: bool,
         secure: bool,
         disable_stream: bool,
     ) -> None:
-        """Initialize an Unifi camera."""
-        self.device: UnifiCamera = camera
+        """Initialize an UniFi camera."""
+        self.device: ProtectCamera = camera
         super().__init__(protect, protect_data, camera, None)
         self.channel = channel
         self._secure = secure

--- a/custom_components/unifiprotect/camera.py
+++ b/custom_components/unifiprotect/camera.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity import Entity
 from pyunifiprotect.api import ProtectApiClient
-from pyunifiprotect.data import Camera as ProtectCamera
+from pyunifiprotect.data import Camera as UFPCamera
 from pyunifiprotect.data.devices import CameraChannel
 from pyunifiprotect.data.types import (
     DoorbellMessageType,
@@ -70,7 +70,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_camera_channels(
     protect: ProtectApiClient,
-) -> Generator[tuple[ProtectCamera, CameraChannel, bool], None, None]:
+) -> Generator[tuple[UFPCamera, CameraChannel, bool], None, None]:
 
     for camera in protect.bootstrap.cameras.values():
         is_default = True
@@ -197,14 +197,14 @@ class ProtectCamera(ProtectEntity, Camera):
         self,
         protect: ProtectApiClient,
         protect_data: ProtectData,
-        camera: ProtectCamera,
+        camera: UFPCamera,
         channel: CameraChannel,
         is_default: bool,
         secure: bool,
         disable_stream: bool,
     ) -> None:
         """Initialize an UniFi camera."""
-        self.device: ProtectCamera = camera
+        self.device: UFPCamera = camera
         super().__init__(protect, protect_data, camera, None)
         self.channel = channel
         self._secure = secure

--- a/custom_components/unifiprotect/config_flow.py
+++ b/custom_components/unifiprotect/config_flow.py
@@ -1,4 +1,4 @@
-"""Config Flow to configure Unifi Protect Integration."""
+"""Config Flow to configure UniFi Protect Integration."""
 from __future__ import annotations
 
 import logging
@@ -33,8 +33,8 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class UnifiProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a Unifi Protect config flow."""
+class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a UniFi Protect config flow."""
 
     VERSION = 2
 

--- a/custom_components/unifiprotect/const.py
+++ b/custom_components/unifiprotect/const.py
@@ -1,4 +1,4 @@
-"""Constant definitions for Unifi Protect Integration."""
+"""Constant definitions for UniFi Protect Integration."""
 
 # from typing_extensions import Required
 from datetime import timedelta

--- a/custom_components/unifiprotect/data.py
+++ b/custom_components/unifiprotect/data.py
@@ -22,12 +22,12 @@ from pyunifiprotect.data.base import ProtectDeviceModel
 from .const import DEVICES_THAT_ADOPT, DEVICES_WITH_ENTITIES
 
 if TYPE_CHECKING:
-    from .entity import AccessTokenMixin, UnifiProtectEntity
+    from .entity import AccessTokenMixin, ProtectEntity
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class UnifiProtectData:
+class ProtectData:
     """Coordinate updates."""
 
     def __init__(

--- a/custom_components/unifiprotect/entity.py
+++ b/custom_components/unifiprotect/entity.py
@@ -1,4 +1,4 @@
-"""Shared Entity definition for Unifi Protect Integration."""
+"""Shared Entity definition for UniFi Protect Integration."""
 from __future__ import annotations
 
 import collections
@@ -28,20 +28,20 @@ from .const import (
     DOMAIN,
     EVENT_UPDATE_TOKENS,
 )
-from .data import UnifiProtectData
+from .data import ProtectData
 
 TOKEN_CHANGE_INTERVAL: Final = timedelta(minutes=1)
 _RND: Final = SystemRandom()
 _LOGGER = logging.getLogger(__name__)
 
 
-class UnifiProtectEntity(Entity):
+class ProtectEntity(Entity):
     """Base class for unifi protect entities."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         device: ProtectDeviceModel,
         description: EntityDescription | None,
     ) -> None:
@@ -54,7 +54,7 @@ class UnifiProtectEntity(Entity):
         if not hasattr(self, "device"):
             self.device: ProtectDeviceModel = device
         self.protect: ProtectApiClient = protect
-        self.protect_data: UnifiProtectData = protect_data
+        self.protect_data: ProtectData = protect_data
         if description is None:
             self._attr_unique_id = f"{self.device.id}"
         else:
@@ -134,7 +134,7 @@ class AccessTokenMixin(Entity):
     @property
     def access_tokens(self) -> collections.deque[str]:
         """Get valid access_tokens for current entity"""
-        assert isinstance(self, UnifiProtectEntity)
+        assert isinstance(self, ProtectEntity)
         return self.protect_data.async_get_or_create_access_tokens(self.entity_id)
 
     @callback
@@ -152,7 +152,7 @@ class AccessTokenMixin(Entity):
 
     @callback
     def _trigger_update_tokens(self, *args, **kwargs):
-        assert isinstance(self, UnifiProtectEntity)
+        assert isinstance(self, ProtectEntity)
         async_dispatcher_send(
             self.hass,
             f"{EVENT_UPDATE_TOKENS}-{self.entity_description.key}-{self.entity_id}",

--- a/custom_components/unifiprotect/light.py
+++ b/custom_components/unifiprotect/light.py
@@ -1,4 +1,4 @@
-"""This component provides Lights for Unifi Protect."""
+"""This component provides Lights for UniFi Protect."""
 from __future__ import annotations
 
 from datetime import timedelta
@@ -25,9 +25,9 @@ from .const import (
     LIGHT_SETTINGS_SCHEMA,
     SERVICE_LIGHT_SETTINGS,
 )
-from .data import UnifiProtectData
-from .entity import UnifiProtectEntity
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .entity import ProtectEntity
+from .models import ProtectEntryData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,12 +40,12 @@ async def async_setup_entry(
     async_add_entities: Callable[[Sequence[Entity]], None],
 ) -> None:
     """Set up lights for UniFi Protect integration."""
-    entry_data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+    entry_data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
     entities = [
-        UnifiProtectLight(
+        ProtectLight(
             protect,
             protect_data,
             device,
@@ -74,16 +74,16 @@ def hass_to_unifi_brightness(value: int) -> int:
     return max(1, round((value / 255) * 6))
 
 
-class UnifiProtectLight(UnifiProtectEntity, LightEntity):
-    """A Ubiquiti Unifi Protect Light Entity."""
+class ProtectLight(ProtectEntity, LightEntity):
+    """A Ubiquiti UniFi Protect Light Entity."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         device: ProtectDeviceModel,
     ):
-        """Initialize an Unifi light."""
+        """Initialize an UniFi light."""
         assert isinstance(device, Light)
         self.device: Light = device
         super().__init__(protect, protect_data, device, None)

--- a/custom_components/unifiprotect/manifest.json
+++ b/custom_components/unifiprotect/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "unifiprotect",
-  "name": "Unifi Protect",
+  "name": "UniFi Protect",
   "documentation": "https://github.com/briis/unifiprotect",
   "issue_tracker": "https://github.com/briis/unifiprotect/issues",
   "config_flow": true,

--- a/custom_components/unifiprotect/media_player.py
+++ b/custom_components/unifiprotect/media_player.py
@@ -1,4 +1,4 @@
-"""Support for Ubiquiti's Unifi Protect NVR."""
+"""Support for Ubiquiti's UniFi Protect NVR."""
 from __future__ import annotations
 
 import logging
@@ -25,9 +25,9 @@ from pyunifiprotect.api import ProtectApiClient
 from pyunifiprotect.data import Camera
 
 from .const import DOMAIN
-from .data import UnifiProtectData
-from .entity import UnifiProtectEntity
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .entity import ProtectEntity
+from .models import ProtectEntryData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,14 +37,14 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: Callable[[Sequence[Entity]], None],
 ) -> None:
-    """Discover cameras with speakers on a Unifi Protect NVR."""
-    entry_data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+    """Discover cameras with speakers on a UniFi Protect NVR."""
+    entry_data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
     async_add_entities(
         [
-            UnifiProtectMediaPlayer(
+            ProtectMediaPlayer(
                 protect,
                 protect_data,
                 camera,
@@ -55,13 +55,13 @@ async def async_setup_entry(
     )
 
 
-class UnifiProtectMediaPlayer(UnifiProtectEntity, MediaPlayerEntity):
+class ProtectMediaPlayer(ProtectEntity, MediaPlayerEntity):
     """A Ubiquiti UniFi Protect Speaker."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         camera: Camera,
     ) -> None:
         """Initialize an UniFi speaker."""

--- a/custom_components/unifiprotect/models.py
+++ b/custom_components/unifiprotect/models.py
@@ -5,13 +5,13 @@ from dataclasses import dataclass
 
 from pyunifiprotect import ProtectApiClient
 
-from .data import UnifiProtectData
+from .data import ProtectData
 
 
 @dataclass
-class UnifiProtectEntryData:
+class ProtectEntryData:
     """Data for the unifiprotect integration."""
 
-    protect_data: UnifiProtectData
+    protect_data: ProtectData
     protect: ProtectApiClient
     disable_stream: bool

--- a/custom_components/unifiprotect/number.py
+++ b/custom_components/unifiprotect/number.py
@@ -1,4 +1,4 @@
-"""This component provides number entities for Unifi Protect."""
+"""This component provides number entities for UniFi Protect."""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -16,9 +16,9 @@ from pyunifiprotect.data import ModelType
 from pyunifiprotect.data.base import ProtectDeviceModel
 
 from .const import DEVICES_WITH_CAMERA, DOMAIN
-from .data import UnifiProtectData
-from .entity import UnifiProtectEntity
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .entity import ProtectEntity
+from .models import ProtectEntryData
 from .utils import get_nested_attr
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,7 +32,7 @@ _KEY_CHIME = "chime_duration"
 
 
 @dataclass
-class UnifiprotectRequiredKeysMixin:
+class ProtectRequiredKeysMixin:
     """Mixin for required keys."""
 
     ufp_max: int
@@ -45,14 +45,12 @@ class UnifiprotectRequiredKeysMixin:
 
 
 @dataclass
-class UnifiProtectNumberEntityDescription(
-    NumberEntityDescription, UnifiprotectRequiredKeysMixin
-):
-    """Describes Unifi Protect Number entity."""
+class ProtectNumberEntityDescription(NumberEntityDescription, ProtectRequiredKeysMixin):
+    """Describes UniFi Protect Number entity."""
 
 
-NUMBER_TYPES: tuple[UnifiProtectNumberEntityDescription, ...] = (
-    UnifiProtectNumberEntityDescription(
+NUMBER_TYPES: tuple[ProtectNumberEntityDescription, ...] = (
+    ProtectNumberEntityDescription(
         key=_KEY_WDR,
         name="Wide Dynamic Range",
         icon="mdi:state-machine",
@@ -65,7 +63,7 @@ NUMBER_TYPES: tuple[UnifiProtectNumberEntityDescription, ...] = (
         ufp_value="isp_settings.wdr",
         ufp_set_function="set_wdr_level",
     ),
-    UnifiProtectNumberEntityDescription(
+    ProtectNumberEntityDescription(
         key=_KEY_MIC_LEVEL,
         name="Microphone Level",
         icon="mdi:microphone",
@@ -78,7 +76,7 @@ NUMBER_TYPES: tuple[UnifiProtectNumberEntityDescription, ...] = (
         ufp_value="mic_volume",
         ufp_set_function="set_mic_volume",
     ),
-    UnifiProtectNumberEntityDescription(
+    ProtectNumberEntityDescription(
         key=_KEY_ZOOM_POS,
         name="Zoom Position",
         icon="mdi:magnify-plus-outline",
@@ -91,7 +89,7 @@ NUMBER_TYPES: tuple[UnifiProtectNumberEntityDescription, ...] = (
         ufp_value="isp_settings.zoom_position",
         ufp_set_function="set_camera_zoom",
     ),
-    UnifiProtectNumberEntityDescription(
+    ProtectNumberEntityDescription(
         key=_KEY_SENSITIVITY,
         name="Motion Sensitivity",
         icon="mdi:walk",
@@ -104,7 +102,7 @@ NUMBER_TYPES: tuple[UnifiProtectNumberEntityDescription, ...] = (
         ufp_value="light_device_settings.pir_sensitivity",
         ufp_set_function="set_sensitivity",
     ),
-    UnifiProtectNumberEntityDescription(
+    ProtectNumberEntityDescription(
         key=_KEY_DURATION,
         name="Duration",
         icon="mdi:camera-timer",
@@ -117,7 +115,7 @@ NUMBER_TYPES: tuple[UnifiProtectNumberEntityDescription, ...] = (
         ufp_value="light_device_settings.pir_duration",
         ufp_set_function="set_duration",
     ),
-    UnifiProtectNumberEntityDescription(
+    ProtectNumberEntityDescription(
         key=_KEY_CHIME,
         name="Duration",
         icon="mdi:camera-timer",
@@ -139,7 +137,7 @@ async def async_setup_entry(
     async_add_entities: Callable[[Sequence[Entity]], None],
 ) -> None:
     """Set up Select entities for UniFi Protect integration."""
-    entry_data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+    entry_data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
@@ -153,7 +151,7 @@ async def async_setup_entry(
                     continue
 
             entities.append(
-                UnifiProtectNumbers(
+                ProtectNumbers(
                     protect,
                     protect_data,
                     device,
@@ -172,18 +170,18 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class UnifiProtectNumbers(UnifiProtectEntity, NumberEntity):
-    """A Unifi Protect Number Entity."""
+class ProtectNumbers(ProtectEntity, NumberEntity):
+    """A UniFi Protect Number Entity."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         device: ProtectDeviceModel,
-        description: UnifiProtectNumberEntityDescription,
+        description: ProtectNumberEntityDescription,
     ) -> None:
         """Initialize the Number Entities."""
-        self.entity_description: UnifiProtectNumberEntityDescription = description
+        self.entity_description: ProtectNumberEntityDescription = description
         super().__init__(protect, protect_data, device, description)
         self._attr_name = f"{self.device.name} {self.entity_description.name}"
         self._attr_max_value = self.entity_description.ufp_max

--- a/custom_components/unifiprotect/select.py
+++ b/custom_components/unifiprotect/select.py
@@ -1,4 +1,4 @@
-"""This component provides select entities for Unifi Protect."""
+"""This component provides select entities for UniFi Protect."""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -29,9 +29,9 @@ from pyunifiprotect.data.base import ProtectDeviceModel
 from pyunifiprotect.data.devices import LCDMessage
 
 from .const import DEVICES_WITH_CAMERA, DOMAIN, TYPE_EMPTY_VALUE
-from .data import UnifiProtectData
-from .entity import UnifiProtectEntity
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .entity import ProtectEntity
+from .models import ProtectEntryData
 from .utils import get_nested_attr
 
 _LOGGER = logging.getLogger(__name__)
@@ -79,7 +79,7 @@ DEVICE_RECORDING_MODES = [
 
 
 @dataclass
-class UnifiprotectRequiredKeysMixin:
+class ProtectRequiredKeysMixin:
     """Mixin for required keys."""
 
     ufp_device_types: set[ModelType]
@@ -91,14 +91,12 @@ class UnifiprotectRequiredKeysMixin:
 
 
 @dataclass
-class UnifiProtectSelectEntityDescription(
-    SelectEntityDescription, UnifiprotectRequiredKeysMixin
-):
-    """Describes Unifi Protect Sensor entity."""
+class ProtectSelectEntityDescription(SelectEntityDescription, ProtectRequiredKeysMixin):
+    """Describes UniFi Protect Sensor entity."""
 
 
-SELECT_TYPES: tuple[UnifiProtectSelectEntityDescription, ...] = (
-    UnifiProtectSelectEntityDescription(
+SELECT_TYPES: tuple[ProtectSelectEntityDescription, ...] = (
+    ProtectSelectEntityDescription(
         key=_KEY_REC_MODE,
         name="Recording Mode",
         icon="mdi:video-outline",
@@ -110,7 +108,7 @@ SELECT_TYPES: tuple[UnifiProtectSelectEntityDescription, ...] = (
         ufp_value="recording_settings.mode",
         ufp_set_function="set_recording_mode",
     ),
-    UnifiProtectSelectEntityDescription(
+    ProtectSelectEntityDescription(
         key=_KEY_VIEWER,
         name="Viewer",
         icon="mdi:view-dashboard",
@@ -121,7 +119,7 @@ SELECT_TYPES: tuple[UnifiProtectSelectEntityDescription, ...] = (
         ufp_value="liveview",
         ufp_set_function="set_liveview",
     ),
-    UnifiProtectSelectEntityDescription(
+    ProtectSelectEntityDescription(
         key=_KEY_LIGHT_MOTION,
         name="Lighting",
         icon="mdi:spotlight",
@@ -133,7 +131,7 @@ SELECT_TYPES: tuple[UnifiProtectSelectEntityDescription, ...] = (
         ufp_value="light_mode_settings.mode",
         ufp_set_function=None,
     ),
-    UnifiProtectSelectEntityDescription(
+    ProtectSelectEntityDescription(
         key=_KEY_IR,
         name="Infrared",
         icon="mdi:circle-opacity",
@@ -145,7 +143,7 @@ SELECT_TYPES: tuple[UnifiProtectSelectEntityDescription, ...] = (
         ufp_value="isp_settings.ir_led_mode",
         ufp_set_function="set_ir_led_model",
     ),
-    UnifiProtectSelectEntityDescription(
+    ProtectSelectEntityDescription(
         key=_KEY_DOORBELL_TEXT,
         name="Doorbell Text",
         icon="mdi:card-text",
@@ -166,7 +164,7 @@ async def async_setup_entry(
     async_add_entities: Callable[[Sequence[Entity]], None],
 ) -> None:
     """Set up Select entities for UniFi Protect integration."""
-    entry_data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+    entry_data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
@@ -179,7 +177,7 @@ async def async_setup_entry(
                     continue
 
             entities.append(
-                UnifiProtectSelects(
+                ProtectSelects(
                     protect,
                     protect_data,
                     device,
@@ -200,21 +198,21 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class UnifiProtectSelects(UnifiProtectEntity, SelectEntity):
-    """A Unifi Protect Select Entity."""
+class ProtectSelects(ProtectEntity, SelectEntity):
+    """A UniFi Protect Select Entity."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         device: ProtectDeviceModel,
-        description: UnifiProtectSelectEntityDescription,
+        description: ProtectSelectEntityDescription,
         options: list[dict[str, Any]] | None,
     ):
         """Initialize the unifi protect select entity."""
         assert isinstance(device, (Camera, Viewer, Light))
         self.device: Camera | Viewer | Light = device
-        self.entity_description: UnifiProtectSelectEntityDescription = description
+        self.entity_description: ProtectSelectEntityDescription = description
         super().__init__(protect, protect_data, device, description)
         self._attr_name = f"{self.device.name} {self.entity_description.name}"
         self._data_key = description.ufp_value

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -1,4 +1,4 @@
-"""This component provides sensors for Unifi Protect."""
+"""This component provides sensors for UniFi Protect."""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -26,16 +26,16 @@ from pyunifiprotect.data.base import ProtectDeviceModel
 from pyunifiprotect.data.nvr import NVR
 
 from .const import ATTR_ENABLED_AT, DEVICES_THAT_ADOPT, DEVICES_WITH_CAMERA, DOMAIN
-from .data import UnifiProtectData
-from .entity import UnifiProtectEntity
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .entity import ProtectEntity
+from .models import ProtectEntryData
 from .utils import above_ha_version, get_nested_attr
 
 _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class UnifiprotectRequiredKeysMixin:
+class ProtectRequiredKeysMixin:
     """Mixin for required keys."""
 
     ufp_device_types: set[ModelType]
@@ -44,10 +44,8 @@ class UnifiprotectRequiredKeysMixin:
 
 
 @dataclass
-class UnifiProtectSensorEntityDescription(
-    SensorEntityDescription, UnifiprotectRequiredKeysMixin
-):
-    """Describes Unifi Protect Sensor entity."""
+class ProtectSensorEntityDescription(SensorEntityDescription, ProtectRequiredKeysMixin):
+    """Describes UniFi Protect Sensor entity."""
 
 
 _KEY_MEMORY = "memory_utilization"
@@ -60,8 +58,8 @@ _KEY_RES_4K = "resolution_4K"
 _KEY_RES_FREE = "resolution_free"
 _KEY_CAPACITY = "record_capacity"
 
-SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
-    UnifiProtectSensorEntityDescription(
+SENSOR_TYPES: tuple[ProtectSensorEntityDescription, ...] = (
+    ProtectSensorEntityDescription(
         key="motion_recording",
         name="Motion Recording",
         icon="mdi:video-outline",
@@ -70,7 +68,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="recording_settings.mode",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key="uptime",
         name="Uptime",
         icon="mdi:clock",
@@ -81,7 +79,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="up_since",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key="light_turn_on",
         name="Light Turn On",
         icon="mdi:leak",
@@ -90,7 +88,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="light_mode_settings.mode",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key="battery_level",
         name="Battery Level",
         native_unit_of_measurement="%",
@@ -100,7 +98,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="battery_status.percentage",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key="light_level",
         name="Light Level",
         native_unit_of_measurement="lx",
@@ -110,7 +108,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="stats.light.value",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key="humidity_level",
         name="Humidity Level",
         native_unit_of_measurement="%",
@@ -120,7 +118,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="stats.humidity.value",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key="temperature_level",
         name="Temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
@@ -130,7 +128,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="stats.temperature.value",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key="ble_signal",
         name="Bluetooth Signal Strength",
         native_unit_of_measurement="dB",
@@ -141,7 +139,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="bluetooth_connection_state.signal_strength",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key="cpu_utilization",
         name="CPU Utilization",
         native_unit_of_measurement="%",
@@ -152,7 +150,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="system_info.cpu.average_load",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key="cpu_temperature",
         name="CPU Temperature",
         native_unit_of_measurement=TEMP_CELSIUS,
@@ -163,7 +161,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="system_info.cpu.temperature",
         precision=None,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key=_KEY_MEMORY,
         name="Memory Utilization",
         native_unit_of_measurement="%",
@@ -174,7 +172,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value=None,
         precision=2,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key=_KEY_DISK,
         name="Storage Utilization",
         native_unit_of_measurement="%",
@@ -185,7 +183,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="storage_stats.utilization",
         precision=2,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key=_KEY_RECORD_TIMELAPSE,
         name="Type: Timelapse Video",
         native_unit_of_measurement="%",
@@ -196,7 +194,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="storage_stats.storage_distribution.timelapse_recordings.percentage",
         precision=2,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key=_KEY_RECORD_ROTATE,
         name="Type: Continuous Video",
         native_unit_of_measurement="%",
@@ -207,7 +205,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="storage_stats.storage_distribution.continuous_recordings.percentage",
         precision=2,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key=_KEY_RECORD_DETECTIONS,
         name="Type: Detections Video",
         native_unit_of_measurement="%",
@@ -218,7 +216,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="storage_stats.storage_distribution.detections_recordings.percentage",
         precision=2,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key=_KEY_RES_HD,
         name="Resolution: HD Video",
         native_unit_of_measurement="%",
@@ -229,7 +227,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="storage_stats.storage_distribution.hd_usage.percentage",
         precision=2,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key=_KEY_RES_4K,
         name="Resolution: 4K Video",
         native_unit_of_measurement="%",
@@ -240,7 +238,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="storage_stats.storage_distribution.uhd_usage.percentage",
         precision=2,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key=_KEY_RES_FREE,
         name="Resolution: Free Space",
         native_unit_of_measurement="%",
@@ -251,7 +249,7 @@ SENSOR_TYPES: tuple[UnifiProtectSensorEntityDescription, ...] = (
         ufp_value="storage_stats.storage_distribution.free.percentage",
         precision=2,
     ),
-    UnifiProtectSensorEntityDescription(
+    ProtectSensorEntityDescription(
         key=_KEY_CAPACITY,
         name="Recording Capcity",
         native_unit_of_measurement="s",
@@ -271,16 +269,14 @@ async def async_setup_entry(
     async_add_entities: Callable[[Sequence[Entity]], None],
 ) -> None:
     """Set up sensors for UniFi Protect integration."""
-    entry_data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+    entry_data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
     sensors = []
     for description in SENSOR_TYPES:
         for device in protect_data.get_by_types(description.ufp_device_types):
-            sensors.append(
-                UnifiProtectSensor(protect, protect_data, device, description)
-            )
+            sensors.append(ProtectSensor(protect, protect_data, device, description))
             _LOGGER.debug(
                 "Adding sensor entity %s for %s",
                 description.name,
@@ -290,18 +286,18 @@ async def async_setup_entry(
     async_add_entities(sensors)
 
 
-class UnifiProtectSensor(UnifiProtectEntity, SensorEntity):
-    """A Ubiquiti Unifi Protect Sensor."""
+class ProtectSensor(ProtectEntity, SensorEntity):
+    """A Ubiquiti UniFi Protect Sensor."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         device: ProtectDeviceModel,
-        description: UnifiProtectSensorEntityDescription,
+        description: ProtectSensorEntityDescription,
     ):
-        """Initialize an Unifi Protect sensor."""
-        self.entity_description: UnifiProtectSensorEntityDescription = description
+        """Initialize an UniFi Protect sensor."""
+        self.entity_description: ProtectSensorEntityDescription = description
         super().__init__(protect, protect_data, device, description)
         self._attr_name = f"{self.device.name} {self.entity_description.name}"
         self._async_update_device_from_protect()

--- a/custom_components/unifiprotect/services.py
+++ b/custom_components/unifiprotect/services.py
@@ -11,7 +11,7 @@ from pyunifiprotect.api import ProtectApiClient
 from pyunifiprotect.exceptions import BadRequest
 
 from .const import CONF_DURATION, CONF_MESSAGE, DOMAIN
-from .models import UnifiProtectEntryData
+from .models import ProtectEntryData
 from .utils import profile_ws_messages
 
 
@@ -20,7 +20,7 @@ def _async_all_ufp_instances(hass: HomeAssistant) -> list[ProtectApiClient]:
     return [
         data.protect
         for data in hass.data[DOMAIN].values()
-        if isinstance(data, UnifiProtectEntryData)
+        if isinstance(data, ProtectEntryData)
     ]
 
 

--- a/custom_components/unifiprotect/switch.py
+++ b/custom_components/unifiprotect/switch.py
@@ -1,4 +1,4 @@
-"""This component provides Switches for Unifi Protect."""
+"""This component provides Switches for UniFi Protect."""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -15,16 +15,16 @@ from pyunifiprotect.data import Camera, Light, ModelType, RecordingMode, VideoMo
 from pyunifiprotect.data.base import ProtectAdoptableDeviceModel, ProtectDeviceModel
 
 from .const import DEVICES_THAT_ADOPT, DEVICES_WITH_CAMERA, DOMAIN
-from .data import UnifiProtectData
-from .entity import UnifiProtectEntity
-from .models import UnifiProtectEntryData
+from .data import ProtectData
+from .entity import ProtectEntity
+from .models import ProtectEntryData
 from .utils import get_nested_attr
 
 _LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
-class UnifiprotectRequiredKeysMixin:
+class ProtectRequiredKeysMixin:
     """Mixin for required keys."""
 
     ufp_device_types: set[ModelType]
@@ -33,10 +33,8 @@ class UnifiprotectRequiredKeysMixin:
 
 
 @dataclass
-class UnifiProtectSwitchEntityDescription(
-    SwitchEntityDescription, UnifiprotectRequiredKeysMixin
-):
-    """Describes Unifi Protect Switch entity."""
+class ProtectSwitchEntityDescription(SwitchEntityDescription, ProtectRequiredKeysMixin):
+    """Describes UniFi Protect Switch entity."""
 
 
 _KEY_STATUS_LIGHT = "status_light"
@@ -45,8 +43,8 @@ _KEY_HIGH_FPS = "high_fps"
 _KEY_PRIVACY_MODE = "privacy_mode"
 _KEY_SSH = "ssh"
 
-SWITCH_TYPES: tuple[UnifiProtectSwitchEntityDescription, ...] = (
-    UnifiProtectSwitchEntityDescription(
+SWITCH_TYPES: tuple[ProtectSwitchEntityDescription, ...] = (
+    ProtectSwitchEntityDescription(
         key=_KEY_STATUS_LIGHT,
         name="Status Light On",
         icon="mdi:led-on",
@@ -55,7 +53,7 @@ SWITCH_TYPES: tuple[UnifiProtectSwitchEntityDescription, ...] = (
         ufp_required_field="feature_flags.has_led_status",
         ufp_value="led_settings.is_enabled",
     ),
-    UnifiProtectSwitchEntityDescription(
+    ProtectSwitchEntityDescription(
         key=_KEY_STATUS_LIGHT,
         name="Status Light On",
         icon="mdi:led-on",
@@ -64,7 +62,7 @@ SWITCH_TYPES: tuple[UnifiProtectSwitchEntityDescription, ...] = (
         ufp_required_field=None,
         ufp_value="light_device_settings.is_indicator_enabled",
     ),
-    UnifiProtectSwitchEntityDescription(
+    ProtectSwitchEntityDescription(
         key=_KEY_HDR_MODE,
         name="HDR Mode",
         icon="mdi:brightness-7",
@@ -73,7 +71,7 @@ SWITCH_TYPES: tuple[UnifiProtectSwitchEntityDescription, ...] = (
         ufp_required_field="feature_flags.has_hdr",
         ufp_value="hdr_mode",
     ),
-    UnifiProtectSwitchEntityDescription(
+    ProtectSwitchEntityDescription(
         key=_KEY_HIGH_FPS,
         name="High FPS",
         icon="mdi:video-high-definition",
@@ -82,7 +80,7 @@ SWITCH_TYPES: tuple[UnifiProtectSwitchEntityDescription, ...] = (
         ufp_required_field="feature_flags.has_highfps",
         ufp_value="video_mode",
     ),
-    UnifiProtectSwitchEntityDescription(
+    ProtectSwitchEntityDescription(
         key=_KEY_PRIVACY_MODE,
         name="Privacy Mode",
         icon="mdi:eye-settings",
@@ -91,7 +89,7 @@ SWITCH_TYPES: tuple[UnifiProtectSwitchEntityDescription, ...] = (
         ufp_required_field="feature_flags.has_privacy_mask",
         ufp_value="is_privacy_on",
     ),
-    UnifiProtectSwitchEntityDescription(
+    ProtectSwitchEntityDescription(
         key=_KEY_SSH,
         name="SSH Enabled",
         icon="mdi:lock",
@@ -110,7 +108,7 @@ async def async_setup_entry(
     async_add_entities: Callable[[Sequence[Entity]], None],
 ) -> None:
     """Set up switches for UniFi Protect integration."""
-    entry_data: UnifiProtectEntryData = hass.data[DOMAIN][entry.entry_id]
+    entry_data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
     protect = entry_data.protect
     protect_data = entry_data.protect_data
 
@@ -123,7 +121,7 @@ async def async_setup_entry(
                     continue
 
             switches.append(
-                UnifiProtectSwitch(
+                ProtectSwitch(
                     protect,
                     protect_data,
                     device,
@@ -139,20 +137,20 @@ async def async_setup_entry(
     async_add_entities(switches)
 
 
-class UnifiProtectSwitch(UnifiProtectEntity, SwitchEntity):
-    """A Unifi Protect Switch."""
+class ProtectSwitch(ProtectEntity, SwitchEntity):
+    """A UniFi Protect Switch."""
 
     def __init__(
         self,
         protect: ProtectApiClient,
-        protect_data: UnifiProtectData,
+        protect_data: ProtectData,
         device: ProtectDeviceModel,
-        description: UnifiProtectSwitchEntityDescription,
+        description: ProtectSwitchEntityDescription,
     ):
-        """Initialize an Unifi Protect Switch."""
+        """Initialize an UniFi Protect Switch."""
         assert isinstance(device, ProtectAdoptableDeviceModel)
         self.device: ProtectAdoptableDeviceModel = device
-        self.entity_description: UnifiProtectSwitchEntityDescription = description
+        self.entity_description: ProtectSwitchEntityDescription = description
         super().__init__(protect, protect_data, device, description)
         self._attr_name = f"{self.device.name} {self.entity_description.name}"
         self._switch_type = self.entity_description.key


### PR DESCRIPTION
Based on feedback from a PR I made to update the UniFi Network integration for HA and looking at other stuff. I renamed all instances of "Unifi" to "UniFi" in the code. This makes our code align more with Ubiquiti's brand.

For classes and such, I just removed "Unifi" all together. So `UnifiProtectData` becomes `ProtectData`. This both makes it easier to stay in-line with Ubiquiti's brand and shortens the classes for a number of classes we have in the code.