### PR TITLE
Bugfixes from 0.11-beta2

### DIFF
--- a/custom_components/unifiprotect/manifest.json
+++ b/custom_components/unifiprotect/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/briis/unifiprotect/issues",
   "config_flow": true,
   "requirements": [
-    "pyunifiprotect==1.2.2"
+    "pyunifiprotect==1.2.3"
   ],
   "dependencies": [
     "http"


### PR DESCRIPTION
* Bumps version of pyunifiprotect to 1.2.3 to get retry logic for thumbnails
* Fixes IndexError for access tokens
* Fixes ValueError if doorbell has never rang