### PR TITLE
Removes extra const. Refactors service setup

### DIFF
--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -8,10 +8,9 @@ import logging
 
 from aiohttp import CookieJar
 from aiohttp.client_exceptions import ServerDisconnectedError
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     CONF_HOST,
-    CONF_ID,
     CONF_PASSWORD,
     CONF_PORT,
     CONF_USERNAME,
@@ -20,7 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
 from pyunifiprotect.data.nvr import NVR
@@ -31,7 +30,6 @@ from .const import (
     CONF_DISABLE_RTSP,
     CONF_DOORBELL_TEXT,
     CONFIG_OPTIONS,
-    DEFAULT_BRAND,
     DEFAULT_SCAN_INTERVAL,
     DEVICE_TYPE_CAMERA,
     DEVICES_FOR_SUBSCRIBE,
@@ -225,30 +223,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     else:
         hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_ADD_DOORBELL_TEXT,
-        functools.partial(add_doorbell_text, hass),
-        DOORBELL_TEXT_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_REMOVE_DOORBELL_TEXT,
-        functools.partial(remove_doorbell_text, hass),
-        DOORBELL_TEXT_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_DEFAULT_DOORBELL_TEXT,
-        functools.partial(set_default_doorbell_text, hass),
-        DOORBELL_TEXT_SCHEMA,
-    )
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_PROFILE_WS,
-        functools.partial(profile_ws, hass),
-        PROFILE_WS_SCHEMA,
-    )
+    services = [
+        (
+            SERVICE_ADD_DOORBELL_TEXT,
+            functools.partial(add_doorbell_text, hass),
+            DOORBELL_TEXT_SCHEMA,
+        ),
+        (
+            SERVICE_REMOVE_DOORBELL_TEXT,
+            functools.partial(remove_doorbell_text, hass),
+            DOORBELL_TEXT_SCHEMA,
+        ),
+        (
+            SERVICE_SET_DEFAULT_DOORBELL_TEXT,
+            functools.partial(set_default_doorbell_text, hass),
+            DOORBELL_TEXT_SCHEMA,
+        ),
+        (SERVICE_PROFILE_WS, functools.partial(profile_ws, hass), PROFILE_WS_SCHEMA),
+    ]
+    for name, method, schema in services:
+        if hass.services.has_service(DOMAIN, name):
+            continue
+        hass.services.async_register(DOMAIN, name, method, schema=schema)
 
     hass.http.register_view(ThumbnailProxyView(hass))
 
@@ -271,6 +267,24 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data: ProtectEntryData = hass.data[DOMAIN][entry.entry_id]
         await data.protect_data.async_stop()
         hass.data[DOMAIN].pop(entry.entry_id)
+
+    loaded_entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state == ConfigEntryState.LOADED
+    ]
+    if len(loaded_entries) == 1:
+        all_services = [
+            SERVICE_ADD_DOORBELL_TEXT,
+            SERVICE_REMOVE_DOORBELL_TEXT,
+            SERVICE_SET_DEFAULT_DOORBELL_TEXT,
+            SERVICE_PROFILE_WS,
+        ]
+        # If this is the last loaded instance of RainMachine, deregister any services
+        # defined during integration setup:
+        for name in all_services:
+            hass.services.async_remove(DOMAIN, name)
+
     return bool(unload_ok)
 
 

--- a/custom_components/unifiprotect/const.py
+++ b/custom_components/unifiprotect/const.py
@@ -9,7 +9,6 @@ from pyunifiprotect.data.types import ModelType, Version
 import voluptuous as vol
 
 DOMAIN = "unifiprotect"
-UNIQUE_ID = "unique_id"
 
 ATTR_CAMERA_ID = "camera_id"
 ATTR_CHIME_ENABLED = "chime_enabled"
@@ -17,7 +16,6 @@ ATTR_CHIME_DURATION = "chime_duration"
 ATTR_DEVICE_MODEL = "device_model"
 ATTR_ENABLED_AT = "enabled_at"
 ATTR_EVENT_SCORE = "event_score"
-ATTR_EVENT_LENGTH = "event_length"
 ATTR_EVENT_OBJECT = "event_object"
 ATTR_EVENT_THUMB = "event_thumbnail"
 ATTR_IS_DARK = "is_dark"
@@ -25,7 +23,6 @@ ATTR_MIC_SENSITIVITY = "mic_sensitivity"
 ATTR_ONLINE = "online"
 ATTR_PRIVACY_MODE = "privacy_mode"
 ATTR_UP_SINCE = "up_since"
-ATTR_VIEWPORT_ID = "viewport_id"
 ATTR_VIEW_ID = "view_id"
 ATTR_WDR_VALUE = "wdr_value"
 ATTR_ZOOM_POSITION = "zoom_position"
@@ -36,7 +33,6 @@ ATTR_BITRATE = "bitrate"
 ATTR_CHANNEL_ID = "channel_id"
 
 CONF_RECORDING_MODE = "recording_mode"
-CONF_CHIME_ON = "chime_on"
 CONF_CHIME_DURATION = "chime_duration"
 CONF_DOORBELL_TEXT = "doorbell_text"
 CONF_DISABLE_RTSP = "disable_rtsp"
@@ -71,13 +67,6 @@ DEFAULT_VERIFY_SSL = False
 RING_INTERVAL = timedelta(seconds=3)
 
 DEVICE_TYPE_CAMERA = "camera"
-DEVICE_TYPE_LIGHT = "light"
-DEVICE_TYPE_DOORBELL = "doorbell"
-DEVICE_TYPE_MOTION = "motion"
-DEVICE_TYPE_VIEWPORT = "viewer"
-DEVICE_TYPE_SENSOR = "sensor"
-DEVICE_TYPE_DARK = "is dark"
-
 DEVICES_WITH_CAMERA = {ModelType.CAMERA}
 DEVICES_WITH_STATUS_LIGHT = {ModelType.CAMERA, ModelType.LIGHT}
 DEVICES_WITH_SENSOR = {
@@ -148,6 +137,7 @@ PLATFORMS = [
     "number",
     "media_player",
 ]
+# CORE: Remove this before merging to core.
 PLATFORMS_NEXT = PLATFORMS + [
     "button",
 ]
@@ -204,6 +194,7 @@ PROFILE_WS_SCHEMA = vol.All(
     cv.has_at_least_one_key(CONF_DEVICE_ID),
 )
 
+# CORE: Remove this before merging to core.
 SET_IR_MODE_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
@@ -278,12 +269,5 @@ SET_DOORBELL_CHIME_DURATION_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
         vol.Required(CONF_CHIME_DURATION, default=300): vol.Coerce(int),
-    }
-)
-
-SET_VIEW_PORT_VIEW_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_ENTITY_ID): cv.string,
-        vol.Required(ATTR_VIEW_ID): cv.string,
     }
 )

--- a/custom_components/unifiprotect/utils.py
+++ b/custom_components/unifiprotect/utils.py
@@ -79,6 +79,10 @@ async def profile_ws_messages(
 
 
 def above_ha_version(major: int, minor: int) -> bool:
+    """Checks if current Home Assistant version if above a specificed one
+
+    CORE: Remove this before merging to core.
+    """
     if MAJOR_VERSION > major:
         return True
     if MAJOR_VERSION < major:


### PR DESCRIPTION
* Removes some unused const variables
* Refactored service setup so the services will only be loaded once (multiple entries will not try to load more) and so they will be removed when all entries are unloaded

I did look into the view, it is kind of wasteful to register it multiple times, but it should be harmless for it to be registered multiple times or be registered when no entries are loaded. 

URL routers (from my experience) use the first matched pattern. If multiple ones are registered, all of the extras are ignored since the first match is the only one that will be used.

Also, because the view itself requires the `entity_id` to look up the `ProtectApiClient`, it will _always_ 404 if no entries are loaded since it cannot find the `ProtectApiClient`, again wasteful, but not harmful.