### PR TITLE
Adds connection state sensors for all devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.11.0-dev (master)
 
+* `NEW`: Adds `phy_rate` and `wifi_signal` sensors so all connection states (BLE, WiFi and Wired) should have a diagnostic sensor
+
+## 0.11.0-beta.2
+
 * `CHANGE`: Allows `device_id` parameter for global service calls to be any device from a UniFi Protect instance
 
 * `NEW`: Adds event thumbnail proxy view.

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -60,6 +60,35 @@ ALL_DEVICES_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         ufp_value="up_since",
     ),
+    ProtectSensorEntityDescription(
+        key="ble_signal",
+        name="Bluetooth Signal Strength",
+        native_unit_of_measurement="dB",
+        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ufp_value="bluetooth_connection_state.signal_strength",
+        ufp_required_field="bluetooth_connection_state.signal_strength",
+    ),
+    ProtectSensorEntityDescription(
+        key="phy_rate",
+        name="Link Speed",
+        native_unit_of_measurement="Mbps",
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ufp_value="wired_connection_state.phy_rate",
+        ufp_required_field="wired_connection_state.phy_rate",
+    ),
+    ProtectSensorEntityDescription(
+        key="wifi_signal",
+        name="WiFi Signal Strength",
+        native_unit_of_measurement="dB",
+        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ufp_value="wifi_connection_state.signal_strength",
+        ufp_required_field="wifi_connection_state.signal_strength",
+    ),
 )
 
 CAMERA_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
@@ -114,15 +143,6 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         device_class=DEVICE_CLASS_TEMPERATURE,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ufp_value="stats.temperature.value",
-    ),
-    ProtectSensorEntityDescription(
-        key="ble_signal",
-        name="Bluetooth Signal Strength",
-        native_unit_of_measurement="dB",
-        device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
-        entity_registry_enabled_default=False,
-        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ufp_value="bluetooth_connection_state.signal_strength",
     ),
 )
 


### PR DESCRIPTION
* Changes `ble_signal` sensor to be available for any device that has a BLE connection (Sense is still the only one with it)
* Adds `phy_rate` sensor for wired devices
* Adds `wifi_signal` for WiFi devices

All connection state sensors are disabled by default.