### PR TITLE
Adds various new entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 * `NEW`: Adds "Received Data", "Transferred Data", "Oldest Recording", "Storage Used", and "Disk Write Rate" sensors for cameras. Disabled by default. Requires "Realtime metrics" option to update in realtime.
 
-* `NEW`: (requires UniFi Protect 1.20.1) Adds "Voltage" sensor for doorbells. Disabled by default. Requires "Realtime metrics" option to update in realtime.
+* `NEW`: (requires UniFi Protect 1.20.1) Adds "Voltage" sensor for doorbells. Disabled by default.
 
 * `NEW`: Adds "System Sounds" switch for cameras with speakers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,22 @@
 
 * `DEPRECATION`: The Motion binary sensor will stop showing details about smart detections in the next version. Use the new separate Detected Object sensor. `event_object` attribute will be removed as well.
 
-* `NEW`: Adds `phy_rate` and `wifi_signal` sensors so all connection states (BLE, WiFi and Wired) should have a diagnostic sensor
+* `NEW`: Adds `phy_rate` and `wifi_signal` sensors so all connection states (BLE, WiFi and Wired) should have a diagnostic sensor. Disabled by default. Requires "Realtime metrics" option to update in realtime.
 
 * `NEW`: Added Detected Object sensor for cameras with smart detections. Values are `none`, `person` or `vehicle`. Contains `event_score` and `event_thumb` attributes.
   * Closes #342
+
+* `NEW`: Adds Paired Camera select entity for Viewports
+
+* `NEW`: Adds "Received Data", "Transferred Data", "Oldest Recording", "Storage Used", and "Disk Write Rate" sensors for cameras. Disabled by default. Requires "Realtime metrics" option to update in realtime.
+
+* `NEW`: (requires UniFi Protect 1.20.1) Adds "Voltage" sensor for doorbells. Disabled by default. Requires "Realtime metrics" option to update in realtime.
+
+* `NEW`: Adds "System Sounds" switch for cameras with speakers
+
+* `NEW`: Adds switches to toggle overlay information for video feeds on all cameras
+
+* `NEW`: Adds switches to toggle smart detection types on cameras with smart detections
 
 ## 0.11.0-beta.2
 

--- a/custom_components/unifiprotect/manifest.json
+++ b/custom_components/unifiprotect/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/briis/unifiprotect/issues",
   "config_flow": true,
   "requirements": [
-    "pyunifiprotect==1.2.3"
+    "pyunifiprotect==1.3.0"
   ],
   "dependencies": [
     "http"

--- a/custom_components/unifiprotect/select.py
+++ b/custom_components/unifiprotect/select.py
@@ -38,6 +38,7 @@ _KEY_REC_MODE = "recording_mode"
 _KEY_VIEWER = "viewer"
 _KEY_LIGHT_MOTION = "light_motion"
 _KEY_DOORBELL_TEXT = "doorbell_text"
+_KEY_PAIRED_CAMERA = "paired_camera"
 
 INFRARED_MODES = [
     {"id": IRLEDMode.AUTO.value, "name": "Auto"},
@@ -125,6 +126,13 @@ LIGHT_SELECTS: tuple[ProtectSelectEntityDescription, ...] = (
         ufp_options=MOTION_MODE_TO_LIGHT_MODE,
         ufp_value="light_mode_settings.mode",
     ),
+    ProtectSelectEntityDescription(
+        key=_KEY_PAIRED_CAMERA,
+        name="Paired Camera",
+        icon="mdi:cctv",
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        ufp_value="camera_id",
+    ),
 )
 
 VIEWPORT_SELECTS: tuple[ProtectSelectEntityDescription, ...] = (
@@ -132,7 +140,6 @@ VIEWPORT_SELECTS: tuple[ProtectSelectEntityDescription, ...] = (
         key=_KEY_VIEWER,
         name="Viewer",
         icon="mdi:view-dashboard",
-        ufp_required_field=None,
         ufp_value="liveview",
         ufp_set_function="set_liveview",
     ),
@@ -192,7 +199,7 @@ class ProtectSelects(ProtectDeviceEntity, SelectEntity):
 
         This is due to possible downstream platforms dependencies on these options.
         """
-        if self.entity_description.key not in (_KEY_VIEWER, _KEY_DOORBELL_TEXT):
+        if self.entity_description.ufp_options is not None:
             return
 
         if self.entity_description.key == _KEY_VIEWER:
@@ -213,6 +220,10 @@ class ProtectSelects(ProtectDeviceEntity, SelectEntity):
                 {"id": "", "name": f"Default Message ({default_message})"},
                 *built_messages,
             ]
+        elif self.entity_description.key == _KEY_PAIRED_CAMERA:
+            options = []
+            for camera in self.data.api.bootstrap.cameras.values():
+                options.append({"id": camera.id, "name": camera.name})
 
         self._attr_options = [item["name"] for item in options]
         self._hass_to_unifi_options = {item["name"]: item["id"] for item in options}
@@ -277,7 +288,12 @@ class ProtectSelects(ProtectDeviceEntity, SelectEntity):
                 _LOGGER.debug("Changed Doorbell LCD Text to: %s", option)
                 return
 
-        if self.entity_description.ufp_enum_type is not None:
+        if self.entity_description.key == _KEY_PAIRED_CAMERA:
+            camera = self.data.api.bootstrap.cameras.get(unifi_value)
+            await self.device.set_paired_camera(camera)
+            _LOGGER.debug("Changed Paired Camera to to: %s", option)
+            return
+        elif self.entity_description.ufp_enum_type is not None:
             unifi_value = self.entity_description.ufp_enum_type(unifi_value)
         elif self.entity_description.key == _KEY_VIEWER:
             unifi_value = self.data.api.bootstrap.liveviews[unifi_value]

--- a/custom_components/unifiprotect/select.py
+++ b/custom_components/unifiprotect/select.py
@@ -273,6 +273,13 @@ class ProtectSelects(ProtectDeviceEntity, SelectEntity):
                 )
                 return
 
+            unifi_value = self._hass_to_unifi_options[option]
+            if self.entity_description.key == _KEY_PAIRED_CAMERA:
+                camera = self.data.api.bootstrap.cameras.get(unifi_value)
+                await self.device.set_paired_camera(camera)
+                _LOGGER.debug("Changed Paired Camera to to: %s", option)
+                return
+
         unifi_value = self._hass_to_unifi_options[option]
         if isinstance(self.device, Camera):
             if self.entity_description.key == _KEY_DOORBELL_TEXT:
@@ -288,12 +295,7 @@ class ProtectSelects(ProtectDeviceEntity, SelectEntity):
                 _LOGGER.debug("Changed Doorbell LCD Text to: %s", option)
                 return
 
-        if self.entity_description.key == _KEY_PAIRED_CAMERA:
-            camera = self.data.api.bootstrap.cameras.get(unifi_value)
-            await self.device.set_paired_camera(camera)
-            _LOGGER.debug("Changed Paired Camera to to: %s", option)
-            return
-        elif self.entity_description.ufp_enum_type is not None:
+        if self.entity_description.ufp_enum_type is not None:
             unifi_value = self.entity_description.ufp_enum_type(unifi_value)
         elif self.entity_description.key == _KEY_VIEWER:
             unifi_value = self.data.api.bootstrap.liveviews[unifi_value]

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -12,10 +12,8 @@ from homeassistant.components.sensor import SensorEntity, SensorEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     DATA_BYTES,
-    DATA_MEGABYTES,
     DATA_RATE_BYTES_PER_SECOND,
     DATA_RATE_MEGABITS_PER_SECOND,
-    DATA_RATE_MEGABYTES_PER_SECOND,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
@@ -23,12 +21,10 @@ from homeassistant.const import (
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_TIMESTAMP,
     DEVICE_CLASS_VOLTAGE,
-    ELECTRIC_POTENTIAL_VOLT,
     ENTITY_CATEGORY_DIAGNOSTIC,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS,
     TEMP_CELSIUS,
-    TIME_DAYS,
     TIME_SECONDS,
 )
 from homeassistant.core import HomeAssistant, callback

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -11,14 +11,25 @@ from homeassistant.components.binary_sensor import DEVICE_CLASS_OCCUPANCY
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    DATA_BYTES,
+    DATA_MEGABYTES,
+    DATA_RATE_BYTES_PER_SECOND,
+    DATA_RATE_MEGABITS_PER_SECOND,
+    DATA_RATE_MEGABYTES_PER_SECOND,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_TIMESTAMP,
+    DEVICE_CLASS_VOLTAGE,
+    ELECTRIC_POTENTIAL_VOLT,
     ENTITY_CATEGORY_DIAGNOSTIC,
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS,
     TEMP_CELSIUS,
+    TIME_DAYS,
+    TIME_SECONDS,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import Entity
@@ -72,7 +83,7 @@ ALL_DEVICES_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key="ble_signal",
         name="Bluetooth Signal Strength",
-        native_unit_of_measurement="dB",
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -82,7 +93,7 @@ ALL_DEVICES_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key="phy_rate",
         name="Link Speed",
-        native_unit_of_measurement="Mbps",
+        native_unit_of_measurement=DATA_RATE_MEGABITS_PER_SECOND,
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ufp_value="wired_connection_state.phy_rate",
@@ -91,7 +102,7 @@ ALL_DEVICES_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key="wifi_signal",
         name="WiFi Signal Strength",
-        native_unit_of_measurement="dB",
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -107,6 +118,58 @@ CAMERA_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
         icon="mdi:video-outline",
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ufp_value="recording_settings.mode",
+    ),
+    ProtectSensorEntityDescription(
+        key="stats_rx",
+        name="Received Data",
+        native_unit_of_measurement=DATA_BYTES,
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ufp_value="stats.rx_bytes",
+    ),
+    ProtectSensorEntityDescription(
+        key="stats_tx",
+        name="Transferred Data",
+        native_unit_of_measurement=DATA_BYTES,
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ufp_value="stats.tx_bytes",
+    ),
+    ProtectSensorEntityDescription(
+        key="oldest_recording",
+        name="Oldest Recording",
+        entity_registry_enabled_default=False,
+        device_class=DEVICE_CLASS_TIMESTAMP,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ufp_value="stats.video.recording_start",
+    ),
+    ProtectSensorEntityDescription(
+        key="storage_used",
+        name="Storage Used",
+        native_unit_of_measurement=DATA_BYTES,
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ufp_value="stats.storage.used",
+    ),
+    ProtectSensorEntityDescription(
+        key="write_rate",
+        name="Disk Write Rate",
+        native_unit_of_measurement=DATA_RATE_BYTES_PER_SECOND,
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ufp_value="stats.storage.rate",
+        precision=2,
+    ),
+    ProtectSensorEntityDescription(
+        key="voltage",
+        name="Voltage",
+        device_class=DEVICE_CLASS_VOLTAGE,
+        entity_registry_enabled_default=False,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ufp_value="voltage",
+        # voltage will be null if device is not camera or not on 1.20.1+
+        ufp_required_field="voltage",
+        precision=2,
     ),
 )
 
@@ -124,7 +187,7 @@ SENSE_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key="battery_level",
         name="Battery Level",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         device_class=DEVICE_CLASS_BATTERY,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ufp_value="battery_status.percentage",
@@ -168,7 +231,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key="cpu_utilization",
         name="CPU Utilization",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:speedometer",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -186,7 +249,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_MEMORY,
         name="Memory Utilization",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:memory",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -195,7 +258,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_DISK,
         name="Storage Utilization",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:harddisk",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -205,7 +268,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_RECORD_TIMELAPSE,
         name="Type: Timelapse Video",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:server",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -215,7 +278,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_RECORD_ROTATE,
         name="Type: Continuous Video",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:server",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -225,7 +288,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_RECORD_DETECTIONS,
         name="Type: Detections Video",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:server",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -235,7 +298,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_RES_HD,
         name="Resolution: HD Video",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:cctv",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -245,7 +308,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_RES_4K,
         name="Resolution: 4K Video",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:cctv",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -255,7 +318,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_RES_FREE,
         name="Resolution: Free Space",
-        native_unit_of_measurement="%",
+        native_unit_of_measurement=PERCENTAGE,
         icon="mdi:cctv",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
@@ -265,7 +328,7 @@ NVR_SENSORS: tuple[ProtectSensorEntityDescription, ...] = (
     ProtectSensorEntityDescription(
         key=_KEY_CAPACITY,
         name="Recording Capcity",
-        native_unit_of_measurement="s",
+        native_unit_of_measurement=TIME_SECONDS,
         icon="mdi:record-rec",
         entity_registry_enabled_default=False,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,

--- a/custom_components/unifiprotect/switch.py
+++ b/custom_components/unifiprotect/switch.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ENTITY_CATEGORY_CONFIG
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
-from pyunifiprotect.data import Camera, Light, RecordingMode, VideoMode, devices
+from pyunifiprotect.data import Camera, RecordingMode, VideoMode
 from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
 
 from .const import DOMAIN
@@ -222,6 +222,7 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
             await getattr(self.device, self.entity_description.ufp_set_function)(True)
             return
 
+        assert isinstance(self.device, Camera)
         if self._switch_type == _KEY_HIGH_FPS:
             _LOGGER.debug("Turning on High FPS mode")
             await self.device.set_video_mode(VideoMode.HIGH_FPS)
@@ -239,6 +240,7 @@ class ProtectSwitch(ProtectDeviceEntity, SwitchEntity):
             await getattr(self.device, self.entity_description.ufp_set_function)(False)
             return
 
+        assert isinstance(self.device, Camera)
         if self._switch_type == _KEY_HIGH_FPS:
             _LOGGER.debug("Turning off High FPS mode")
             await self.device.set_video_mode(VideoMode.DEFAULT)


### PR DESCRIPTION
* Bumps pyunifiprotect to 1.3.0
* Adds `ufp_set_function` for switch entities
* Replaces various unit_of_measures with constants from HA

* `NEW`: Adds Paired Camera select entity for Viewports

* `NEW`: Adds "Received Data", "Transferred Data", "Oldest Recording", "Storage Used", and "Disk Write Rate" sensors for cameras. Disabled by default. Requires "Realtime metrics" option to update in realtime.

* `NEW`: (requires UniFi Protect 1.20.1) Adds "Voltage" sensor for doorbells. Disabled by default.

* `NEW`: Adds "System Sounds" switch for cameras with speakers

* `NEW`: Adds switches to toggle overlay information for video feeds on all cameras
 
* `NEW`: Adds switches to toggle smart detection types on cameras with smart detections