### PR TITLE
Adds CONF_OVERRIDE_CHOST and new dynamic doorbell service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 0.11.0-dev (master)
 
+* `NEW`: Adds `unifiprotect.set_doorbell_message` service. This is just like the `unifiprotect.set_doorbell_lcd_message`, but it is not deprecated and it requires the Doorbell Text Select entity instead of the Camera entity. Should **only** be used to set dynamic doorbell text messages (i.e. setting the current outdoor temperate on your doorbell). If you want to use static custom messages, use the Doorbell Text Select entity and the `unifiprotect.add_doorbell_text` / `unifiprotect.remove_doorbell_text` service. `unifiprotect.set_doorbell_lcd_message` is still deprecated and will still be removed in the next release.
+  * Closes #396
+
+* `NEW`: Adds "Override Connection Host" config option. This will force your RTSP(S) connection IP address to be the same as everything else. Should only be used if you need to forcibly use a different IP address.
+  * For sure closes #248
+
+* `FIX`: Reset event_thumbnail attribute for Motion binary sensor after motion has ended
+
+* `FIX`: Change unit for signal strength from db to dbm. (fixes Camera Wifi Signal Strength should be dBm not dB)
+  * Closes #394
+
+## 0.11.0-beta.3
+
 * `DEPRECATION`: The Motion binary sensor will stop showing details about smart detections in the next version. Use the new separate Detected Object sensor. `event_object` attribute will be removed as well.
 
 * `NEW`: Adds `phy_rate` and `wifi_signal` sensors so all connection states (BLE, WiFi and Wired) should have a diagnostic sensor. Disabled by default. Requires "Realtime metrics" option to update in realtime.

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -27,6 +27,7 @@ from pyunifiprotect.data import ModelType
 from .const import (
     CONF_ALL_UPDATES,
     CONF_DOORBELL_TEXT,
+    CONF_OVERRIDE_CHOST,
     CONFIG_OPTIONS,
     DEFAULT_SCAN_INTERVAL,
     DEVICE_TYPE_CAMERA,
@@ -178,6 +179,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         verify_ssl=entry.data[CONF_VERIFY_SSL],
         session=session,
         subscribed_models=DEVICES_FOR_SUBSCRIBE,
+        override_connection_host=entry.options.get(CONF_OVERRIDE_CHOST, False),
         ignore_stats=not entry.options.get(CONF_ALL_UPDATES, False),
     )
     _LOGGER.debug("Connect to UniFi Protect")

--- a/custom_components/unifiprotect/config_flow.py
+++ b/custom_components/unifiprotect/config_flow.py
@@ -24,6 +24,7 @@ import voluptuous as vol
 from .const import (
     CONF_ALL_UPDATES,
     CONF_DISABLE_RTSP,
+    CONF_OVERRIDE_CHOST,
     DEFAULT_PORT,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
@@ -59,6 +60,7 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             options={
                 CONF_DISABLE_RTSP: False,
                 CONF_ALL_UPDATES: False,
+                CONF_OVERRIDE_CHOST: False,
             },
         )
 
@@ -205,6 +207,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_ALL_UPDATES,
                         default=self.config_entry.options.get(CONF_ALL_UPDATES, False),
+                    ): bool,
+                    vol.Optional(
+                        CONF_OVERRIDE_CHOST,
+                        default=self.config_entry.options.get(
+                            CONF_OVERRIDE_CHOST, False
+                        ),
                     ): bool,
                 }
             ),

--- a/custom_components/unifiprotect/const.py
+++ b/custom_components/unifiprotect/const.py
@@ -51,6 +51,7 @@ CONF_POSITION = "position"
 CONF_SENSITIVITY = "sensitivity"
 CONF_VALUE = "value"
 CONF_ALL_UPDATES = "all_updates"
+CONF_OVERRIDE_CHOST = "override_connection_host"
 
 CONFIG_OPTIONS = [
     CONF_ALL_UPDATES,
@@ -84,6 +85,8 @@ SERVICE_PROFILE_WS = "profile_ws_messages"
 SERVICE_ADD_DOORBELL_TEXT = "add_doorbell_text"
 SERVICE_REMOVE_DOORBELL_TEXT = "remove_doorbell_text"
 SERVICE_SET_DEFAULT_DOORBELL_TEXT = "set_default_doorbell_text"
+SERVICE_SET_DOORBELL_MESSAGE = "set_doorbell_message"
+
 SERVICE_LIGHT_SETTINGS = "light_settings"
 SERVICE_SET_RECORDING_MODE = "set_recording_mode"
 SERVICE_SET_IR_MODE = "set_ir_mode"

--- a/custom_components/unifiprotect/manifest.json
+++ b/custom_components/unifiprotect/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/briis/unifiprotect/issues",
   "config_flow": true,
   "requirements": [
-    "pyunifiprotect==1.3.0"
+    "pyunifiprotect==1.3.1"
   ],
   "dependencies": [
     "http"

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -74,10 +74,43 @@ set_default_doorbell_text:
       required: true
       selector:
         text:
+set_doorbell_message:
+  name: Set Doorbell message
+  description: >
+    Use to dynamically set the message on a Doorbell LCD screen. Should only be used to set dynamic messages
+    (i.e. setting the current outdoor temperature on your Doorbell). Static messages should still using the Select entity and the
+    add_doorbell_text / remove_doorbell_text services.
+  fields:
+    entity_id:
+      name: Doorbell Text
+      description: (Required) Doorbell to display message on
+      example: "select.front_doorbell_camera_doorbell_text"
+      required: true
+      selector:
+        entity:
+          integration: unifiprotect
+          domain: select
+    message:
+      name: Message to display
+      description: (Required) Message to display on LCD Panel. Max 30 characters
+      example: "Welcome | 09:23 | 25°C"
+      required: true
+      selector:
+        text:
+    duration:
+      name: Duration (minutes)
+      description: "(Optional) Number of minutes to display message, before returning to default. Leave blank to display always"
+      example: 5
+      selector:
+        number:
+          min: 1
+          max: 120
+          step: 1
+          mode: slider
 
 set_recording_mode:
-  name: Set Recording Mode
-  description: "Set recording mode for the camera"
+  name: DEPRECATED Set Recording Mode
+  description: "Set recording mode for the camera. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -100,8 +133,8 @@ set_recording_mode:
             - "detections"
             - "never"
 set_ir_mode:
-  name: Set Infrared mode
-  description: "Set Infrared mode for the camera"
+  name: DEPRECATED Set Infrared mode
+  description: "Set Infrared mode for the camera. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -124,8 +157,8 @@ set_ir_mode:
             - "on"
             - "off"
 set_status_light:
-  name: Set Status Lights
-  description: "Turn the Cameras Led Light on or off"
+  name: DEPRECATED Set Status Lights
+  description: "Turn the Cameras Led Light on or off. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -143,8 +176,8 @@ set_status_light:
       selector:
         boolean:
 set_hdr_mode:
-  name: Set High Dynamic Range mode (HDR)
-  description: "Turn the Cameras HDR mode on or off"
+  name: DEPRECATED Set High Dynamic Range mode (HDR)
+  description: "Turn the Cameras HDR mode on or off. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -162,7 +195,7 @@ set_hdr_mode:
       selector:
         boolean:
 set_highfps_video_mode:
-  name: Set High FPS video mode
+  name: DEPRECATED Set High FPS video mode
   description: "Turn the Cameras High FPS mode on or off (Only G4 Cameras)"
   fields:
     entity_id:
@@ -181,8 +214,8 @@ set_highfps_video_mode:
       selector:
         boolean:
 set_doorbell_lcd_message:
-  name: Set Doorbell LCD message
-  description: "Display a message on the LCD Screen on the G4 Doorbell"
+  name: DEPRECATED Set Doorbell LCD message
+  description: "Display a message on the LCD Screen on the G4 Doorbell. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -211,8 +244,8 @@ set_doorbell_lcd_message:
           step: 1
           mode: slider
 set_mic_volume:
-  name: Set microphone volume
-  description: "Sets the microphone sensitivity volume"
+  name: DEPRECATED Set microphone volume
+  description: "Sets the microphone sensitivity volume. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -234,8 +267,8 @@ set_mic_volume:
           step: 1
           mode: slider
 set_privacy_mode:
-  name: Set Privacy Mode
-  description: "Enables or disables a full cover Privacy Zone for the Camera"
+  name: DEPRECATED Set Privacy Mode
+  description: "Enables or disables a full cover Privacy Zone for the Camera. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -273,8 +306,8 @@ set_privacy_mode:
             - "detections"
             - "never"
 set_zoom_position:
-  name: Set Zoom Position
-  description: "Sets the cameras optical Zoom Position"
+  name: DEPRECATED Set Zoom Position
+  description: "Sets the cameras optical Zoom Position. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -296,8 +329,8 @@ set_zoom_position:
           step: 1
           mode: slider
 set_wdr_value:
-  name: Set Wide Dynamic Range (WDR)
-  description: "Sets the cameras Wide Dynamic Range value"
+  name: DEPRECATED Set Wide Dynamic Range (WDR)
+  description: "Sets the cameras Wide Dynamic Range value. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -319,8 +352,8 @@ set_wdr_value:
           step: 1
           mode: slider
 light_settings:
-  name: Light Settings
-  description: "Adjust settings on a UniFi attached Floodlight"
+  name: DEPRECATED Light Settings
+  description: "Adjust settings on a UniFi attached Floodlight. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -374,8 +407,8 @@ light_settings:
           step: 1
           mode: slider
 set_doorbell_chime_duration:
-  name: Set the Chime duration attached to a Doorbell
-  description: "Set the duration for doorbell chime"
+  name: DEPRECATED Set the Chime duration attached to a Doorbell
+  description: "Set the duration for doorbell chime. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Entity ID
@@ -398,8 +431,8 @@ set_doorbell_chime_duration:
           step: 100
           mode: slider
 set_viewport_view:
-  name: Set Viewport View
-  description: "Change the Liveview on the specified Viewport Device"
+  name: DEPRECATED Set Viewport View
+  description: "Change the Liveview on the specified Viewport Device. DEPRECATED: Will be removed in next version."
   fields:
     entity_id:
       name: Viewport ID

--- a/custom_components/unifiprotect/strings.json
+++ b/custom_components/unifiprotect/strings.json
@@ -39,7 +39,8 @@
                 "description": "Custom Doorbell Texts should be a comma separated list of texts that will usable in a select for your doorbell. These will be in addition to the ones provided by UniFi Protect. Leave blank if you do not have a doorbell camera.",
                 "data": {
                     "disable_rtsp": "Disable the RTSP stream",
-                    "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)"
+                    "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)",
+                    "override_connection_host": "Override Connection Host"
                 }
             }
         }

--- a/custom_components/unifiprotect/translations/en.json
+++ b/custom_components/unifiprotect/translations/en.json
@@ -37,7 +37,8 @@
             "init": {
                 "data": {
                     "all_updates": "Realtime metrics (WARNING: Greatly increases CPU usage)",
-                    "disable_rtsp": "Disable the RTSP stream"
+                    "disable_rtsp": "Disable the RTSP stream",
+                    "override_connection_host": "Override Connection Host"
                 },
                 "description": "Custom Doorbell Texts should be a comma separated list of texts that will usable in a select for your doorbell. These will be in addition to the ones provided by UniFi Protect. Leave blank if you do not have a doorbell camera.",
                 "title": "UniFi Protect Options"


### PR DESCRIPTION
* `NEW`: Adds `unifiprotect.set_doorbell_message` service. This is just like the `unifiprotect.set_doorbell_lcd_message`, but it is not deprecated and it requires the Doorbell Text Select entity instead of the Camera entity. Should **only** be used to set dynamic doorbell text messages (i.e. setting the current outdoor temperate on your doorbell). If you want to use static custom messages, use the Doorbell Text Select entity and the `unifiprotect.add_doorbell_text` / `unifiprotect.remove_doorbell_text` service. `unifiprotect.set_doorbell_lcd_message` is still deprecated and will still be removed in the next release.
  * Closes #396

* `NEW`: Adds "Override Connection Host" config option. This will force your RTSP(S) connection IP address to be the same as everything else. Should only be used if you need to forcibly use a different IP address.
  * For sure closes #248