### PR TITLE
Adds dynamic doorbell blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ As part of the integration, we provide a couple of blueprints that you can use o
 
 [![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fbriis%2Funifiprotect%2Fmaster%2Fblueprints%2Fautomation%2Funifiprotect%2Fpush_notification_smart_event.yaml)
 
+### Dynamic Doorbell Messages
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fbriis%2Funifiprotect%2Fmaster%2Fblueprints%2Fautomation%2Funifiprotect%2Fdynamic_doorbell.yaml)
+
 ### Enable Debug Logging
 
 If logs are needed for debugging or reporting an issue, use the following configuration.yaml:

--- a/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
+++ b/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
@@ -3,7 +3,7 @@ blueprint:
   description: |
     ## UniFi Protect Dynamic Doorbell
 
-    This blueprint will dynamically update the text on the LCD display for your UniFi Protect Doorbell
+    This blueprint will dynamically update the text on the LCD display for your UniFi Protect Doorbell. Will automatically run once per minute and update your Doorbell LCD Screen.
 
     ### Required Settings
 
@@ -13,7 +13,6 @@ blueprint:
 
       - Text template format you want to display (see more below)
       - Temperature sensor entity so you can display temperature on screen
-      - How often to update screen
       - Time formatting string for formatting `{ctime}` template (see more below)
 
     ### Requirements
@@ -47,8 +46,7 @@ blueprint:
           domain: select
     temp_entity:
       name: (Optional) Temperature Sensor Entity
-      description: >
-        Temperature sensor to use. Adds `{temp}` var to template.
+      description: Temperature sensor to use. Adds `{temp}` var to template.
       default: ""
       selector:
         entity:
@@ -66,23 +64,11 @@ blueprint:
     time_format:
       name: (Optional) Time Format String
       description: >
-        Python datetime format code string for the event trigger time. This string is
-        the actually time the doorbell event was triggered in case the automation or
-        notification is delayed. Manual triggers will cause this to always be the time
-        of the previous event.
+        Python datetime format code string for the `{ctime}` variable.
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
       default: "%I:%M %p"
       selector:
         text:
-    update_interval:
-      name: (Optional) Update Interval
-      description: How often to update screen.
-      default: 1
-      selector:
-        number:
-          max: 120
-          min: 1
-          unit_of_measurement: minutes
 
 mode: single
 max_exceeded: silent
@@ -95,7 +81,7 @@ variables:
 
 trigger:
   - platform: time_pattern
-    minutes: !input update_interval
+    minutes: "*"
 
 action:
   - service: unifiprotect.set_doorbell_message

--- a/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
+++ b/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
@@ -21,7 +21,7 @@ blueprint:
     To take full effect of this automation blueprint, your Home Assistant instance needs some setup beforehand.
 
     - A UniFi Protect NVR running on a UDM Pro, UNVR or other Protect Console
-    - The [unifiprotect][1] integration
+    - The [unifiprotect][1] integration version 0.11-beta4 or newer
     - A UniFi G4 Doorbell
 
     ### Text Template

--- a/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
+++ b/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
@@ -3,7 +3,7 @@ blueprint:
   description: |
     ## UniFi Protect Dynamic Doorbell
 
-    This blueprint will dyanmically update the text on the LCD display if your UniFi Protect Doorbell
+    This blueprint will dynamically update the text on the LCD display if your UniFi Protect Doorbell
 
     ### Required Settings
 
@@ -30,7 +30,7 @@ blueprint:
 
     The follow variables will injected and replaced at render time as well (note the _single_ curly bracket, not 2):
 
-      - `{ctime}` -- current time, formatting accordingt to "Time Format String" option
+      - `{ctime}` -- current time, formatting according to "Time Format String" option
       - `{temp}` -- current temperature from the "Temperature Sensor Entity" option
 
     [1]: https://community.home-assistant.io/t/custom-component-unifi-protect/158041
@@ -48,7 +48,7 @@ blueprint:
     temp_entity:
       name: (Optional) Temperature Sensor Entity
       description: >
-        Temperture sensor to use. Adds `{temp}` var to template.
+        Temperature sensor to use. Adds `{temp}` var to template.
       default: ""
       selector:
         entity:

--- a/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
+++ b/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
@@ -57,17 +57,16 @@ blueprint:
     text_template:
       name: (Optional) Text Template
       description: >
-        The notification target for mobile apps notifications. Should be only the
-        specific service name in the notify domain.
-        https://companion.home-assistant.io/docs/notifications/notifications-basic#sending-notifications-to-multiple-devices
+        Message template to disable on doorbell. Can be any HA template string.
+        Final generated string must be 30 characters or less.
       default: "Welcome | {ctime}"
       selector:
         text:
     always_run:
       name: (Optional) Ignore current state?
       description: >
-        Ingore the current state of the doorbell text message. If true, will always run every
-        minute, potietnally resetting a custom static message you set. If false, will only
+        Ignore the current state of the doorbell text message. If true, will always run every
+        minute, potentially resetting a custom static message you set. If false, will only
         run every minute if the current text is the "Default Message" option or the
         "unknown" (meaning it is already set to a dynamic value).
       default: false

--- a/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
+++ b/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
@@ -3,13 +3,9 @@ blueprint:
   description: |
     ## UniFi Protect Dynamic Doorbell
 
-    This blueprint will dynamically update the text on the LCD display for your UniFi Protect 
-    Doorbell. Will automatically run once per minute and update your Doorbell LCD Screen.
+    This blueprint will dynamically update the text on the LCD display for your UniFi Protect Doorbell. Will automatically run once per minute and update your Doorbell LCD Screen.
 
-    For this automation to run, you need to ensure your doorbell LCD display is set to the 
-    "Default Message" option, otherwise it will never run. This is to still allow you to set 
-    static custom messages like "LEAVE PACKAGE AT THE DOOR" without being overriden by the 
-    automation. This behavior can be disabled in the options.
+    For this automation to run, you need to ensure your doorbell LCD display is set to the "Default Message" option. This is to still allow you to set static custom messages like "LEAVE PACKAGE AT THE DOOR" without being overridden by the automation. This behavior can be disabled in the options.
 
     ### Required Settings
 
@@ -70,7 +66,7 @@ blueprint:
     always_run:
       name: (Optional) Ignore current state?
       description: >
-        Ingore the current state of the doorbell text message. If true, will always run every 
+        Ingore the current state of the doorbell text message. If true, will always run every
         minute, potietnally resetting a custom static message you set. If false, will only
         run every minute if the current text is the "Default Message" option or the
         "unknown" (meaning it is already set to a dynamic value).

--- a/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
+++ b/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
@@ -1,0 +1,113 @@
+blueprint:
+  name: UniFi Protect Dynamic Doorbell
+  description: |
+    ## UniFi Protect Dynamic Doorbell
+
+    This blueprint will dyanmically update the text on the LCD display if your UniFi Protect Doorbell
+
+    ### Required Settings
+
+      - UniFi Protect Doorbell Sensor
+
+    ### Optional Settings
+
+      - Text template format you want to display (see more below)
+      - Temperature sensor entity so you can display temperature on screen
+      - How often to update screen
+      - Time formatting string for formatting `{ctime}` template (see more below)
+
+    ### Requirements
+
+    To take full effect of this automation blueprint, your Home Assistant instance needs some setup beforehand.
+
+    - A UniFi Protect NVR running on a UDM Pro, UNVR or other Protect Console
+    - The [unifiprotect][1] integration
+    - A UniFi G4 Doorbell
+
+    ### Text Template
+
+    The text that is display on your doorbell is configurable using the templating engine. Any [Home Assistant Templating][2] _should_ work in the template.
+
+    The follow variables will injected and replaced at render time as well (note the _single_ curly bracket, not 2):
+
+      - `{ctime}` -- current time, formatting accordingt to "Time Format String" option
+      - `{temp}` -- current temperature from the "Temperature Sensor Entity" option
+
+    [1]: https://community.home-assistant.io/t/custom-component-unifi-protect/158041
+    [2]: https://www.home-assistant.io/docs/configuration/templating/
+  domain: automation
+  input:
+    doorbell:
+      name: Doorbell Entity
+      description: >
+        The doorbell sensor you want to trigger notifications for.
+      selector:
+        entity:
+          integration: unifiprotect
+          domain: select
+    temp_entity:
+      name: (Optional) Temperature Sensor Entity
+      description: >
+        Temperture sensor to use. Adds `{temp}` var to template.
+      default: ""
+      selector:
+        entity:
+          domain: sensor
+          device_class: temperature
+    text_template:
+      name: (Optional) Text Template
+      description: >
+        The notification target for mobile apps notifications. Should be only the
+        specific service name in the notify domain.
+        https://companion.home-assistant.io/docs/notifications/notifications-basic#sending-notifications-to-multiple-devices
+      default: "Welcome | {ctime}"
+      selector:
+        text:
+    time_format:
+      name: (Optional) Time Format String
+      description: >
+        Python datetime format code string for the event trigger time. This string is 
+        the actually time the doorbell event was triggered in case the automation or 
+        notification is delayed. Manual triggers will cause this to always be the time 
+        of the previous event.
+        https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+      default: "%I:%M %p"
+      selector:
+        text:
+    update_interval:
+      name: (Optional) Update Interval
+      description: How often to update screen.
+      default: 1
+      selector:
+        number:
+          max: 120
+          min: 1
+          unit_of_measurement: minutes
+
+mode: single
+max_exceeded: silent
+
+variables:
+  # input vars
+  input_time_format: !input time_format
+  input_text_template: !input text_template
+  input_temp_entity: !input temp_entity
+
+trigger:
+  - platform: time_pattern
+    minutes: !input update_interval
+
+action:
+  - service: unifiprotect.set_doorbell_message
+    data:
+      entity_id: !input doorbell
+      message: |
+        {%- set ctime=as_local(now()).strftime(input_time_format) -%}
+        {%- if input_temp_entity != "" -%}
+          {%- if is_state(input_temp_entity, 'unavailable') -%}
+            {%- set temp="" %}
+          {%- else -%}
+            {%- set temp="{}{}".format(int(states[input_temp_entity].state), state_attr(input_temp_entity, "unit_of_measurement")) -%}
+          {%- endif -%}
+        {%- endif -%}
+        {{ input_text_template.replace("{ctime}", ctime).replace("{temp}", temp) }}

--- a/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
+++ b/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
@@ -57,7 +57,7 @@ blueprint:
     text_template:
       name: (Optional) Text Template
       description: >
-        Message template to disable on doorbell. Can be any HA template string.
+        Message template to display on doorbell. Can be any HA template string.
         Final generated string must be 30 characters or less.
       default: "Welcome | {ctime}"
       selector:

--- a/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
+++ b/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
@@ -3,7 +3,13 @@ blueprint:
   description: |
     ## UniFi Protect Dynamic Doorbell
 
-    This blueprint will dynamically update the text on the LCD display for your UniFi Protect Doorbell. Will automatically run once per minute and update your Doorbell LCD Screen.
+    This blueprint will dynamically update the text on the LCD display for your UniFi Protect 
+    Doorbell. Will automatically run once per minute and update your Doorbell LCD Screen.
+
+    For this automation to run, you need to ensure your doorbell LCD display is set to the 
+    "Default Message" option, otherwise it will never run. This is to still allow you to set 
+    static custom messages like "LEAVE PACKAGE AT THE DOOR" without being overriden by the 
+    automation. This behavior can be disabled in the options.
 
     ### Required Settings
 
@@ -61,6 +67,16 @@ blueprint:
       default: "Welcome | {ctime}"
       selector:
         text:
+    always_run:
+      name: (Optional) Ignore current state?
+      description: >
+        Ingore the current state of the doorbell text message. If true, will always run every 
+        minute, potietnally resetting a custom static message you set. If false, will only
+        run every minute if the current text is the "Default Message" option or the
+        "unknown" (meaning it is already set to a dynamic value).
+      default: false
+      selector:
+        boolean:
     time_format:
       name: (Optional) Time Format String
       description: >
@@ -75,13 +91,18 @@ max_exceeded: silent
 
 variables:
   # input vars
+  input_doorbell: !input doorbell
   input_time_format: !input time_format
   input_text_template: !input text_template
   input_temp_entity: !input temp_entity
+  input_always_run: !input always_run
 
 trigger:
   - platform: time_pattern
     minutes: "*"
+
+condition:
+  - "{{ input_always_run or is_state(input_doorbell, 'unknown') or states[input_doorbell].state.startswith('Default Message') }}"
 
 action:
   - service: unifiprotect.set_doorbell_message

--- a/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
+++ b/blueprints/automation/unifiprotect/dynamic_doorbell.yaml
@@ -3,7 +3,7 @@ blueprint:
   description: |
     ## UniFi Protect Dynamic Doorbell
 
-    This blueprint will dynamically update the text on the LCD display if your UniFi Protect Doorbell
+    This blueprint will dynamically update the text on the LCD display for your UniFi Protect Doorbell
 
     ### Required Settings
 
@@ -66,9 +66,9 @@ blueprint:
     time_format:
       name: (Optional) Time Format String
       description: >
-        Python datetime format code string for the event trigger time. This string is 
-        the actually time the doorbell event was triggered in case the automation or 
-        notification is delayed. Manual triggers will cause this to always be the time 
+        Python datetime format code string for the event trigger time. This string is
+        the actually time the doorbell event was triggered in case the automation or
+        notification is delayed. Manual triggers will cause this to always be the time
         of the previous event.
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
       default: "%I:%M %p"

--- a/blueprints/automation/unifiprotect/push_notification_doorbell_event.yaml
+++ b/blueprints/automation/unifiprotect/push_notification_doorbell_event.yaml
@@ -104,7 +104,7 @@ blueprint:
       name: (Optional) Time Format String
       description: >
         Python datetime format code string for the event trigger time. This string is
-        the actually time the doorbell event was triggered in case the automation or
+        the actual time the doorbell event was triggered in case the automation or
         notification is delayed. Manual triggers will cause this to always be the time
         of the previous event.
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes

--- a/blueprints/automation/unifiprotect/push_notification_doorbell_event.yaml
+++ b/blueprints/automation/unifiprotect/push_notification_doorbell_event.yaml
@@ -103,9 +103,9 @@ blueprint:
     time_format:
       name: (Optional) Time Format String
       description: >
-        Python datetime format code string for the event trigger time. This string is 
-        the actually time the doorbell event was triggered in case the automation or 
-        notification is delayed. Manual triggers will cause this to always be the time 
+        Python datetime format code string for the event trigger time. This string is
+        the actually time the doorbell event was triggered in case the automation or
+        notification is delayed. Manual triggers will cause this to always be the time
         of the previous event.
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
       default: "%I:%M %p"

--- a/blueprints/automation/unifiprotect/push_notification_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/push_notification_motion_event.yaml
@@ -103,7 +103,7 @@ blueprint:
       name: (Optional) Time Format String
       description: >
         Python datetime format code string for the event trigger time. This string is
-        the actually time the motion event was triggered in case the automation or
+        the actual time the motion event was triggered in case the automation or
         notification is delayed. Manual triggers will cause this to always be the time
         of the previous event.
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes

--- a/blueprints/automation/unifiprotect/push_notification_motion_event.yaml
+++ b/blueprints/automation/unifiprotect/push_notification_motion_event.yaml
@@ -102,9 +102,9 @@ blueprint:
     time_format:
       name: (Optional) Time Format String
       description: >
-        Python datetime format code string for the event trigger time. This string is 
-        the actual time the moton event was triggered in case the automation or 
-        notification is delayed. Manual triggers will cause this to always be the time 
+        Python datetime format code string for the event trigger time. This string is
+        the actually time the motion event was triggered in case the automation or
+        notification is delayed. Manual triggers will cause this to always be the time
         of the previous event.
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
       default: "%I:%M %p"

--- a/blueprints/automation/unifiprotect/push_notification_smart_event.yaml
+++ b/blueprints/automation/unifiprotect/push_notification_smart_event.yaml
@@ -112,7 +112,7 @@ blueprint:
       name: (Optional) Time Format String
       description: >
         Python datetime format code string for the event trigger time. This string is
-        the actually time the motion event was triggered in case the automation or
+        the actual time the motion event was triggered in case the automation or
         notification is delayed. Manual triggers will cause this to always be the time
         of the previous event.
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes

--- a/blueprints/automation/unifiprotect/push_notification_smart_event.yaml
+++ b/blueprints/automation/unifiprotect/push_notification_smart_event.yaml
@@ -111,9 +111,9 @@ blueprint:
     time_format:
       name: (Optional) Time Format String
       description: >
-        Python datetime format code string for the event trigger time. This string is 
-        the actual time the moton event was triggered in case the automation or 
-        notification is delayed. Manual triggers will cause this to always be the time 
+        Python datetime format code string for the event trigger time. This string is
+        the actually time the motion event was triggered in case the automation or
+        notification is delayed. Manual triggers will cause this to always be the time
         of the previous event.
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
       default: "%I:%M %p"


### PR DESCRIPTION
Another blueprint based on the awesome idea from @edwardmp and https://github.com/briis/unifiprotect/issues/396

The automation by default will only run if the current LCD text is the default message or it is "unknown" (meaning it is already dynamically set). This will let you still ad-hoc use existing static messages like "LEAVE PACKAGE AT THE DOOR" and once you clean it, the automation will start running again.

[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fbriis%2Funifiprotect%2Fblueprint-dynamic-doorbell%2Fblueprints%2Fautomation%2Funifiprotect%2Fdynamic_doorbell.yaml)

![image](https://user-images.githubusercontent.com/490848/146035962-7f213063-06e1-4ef4-9855-b7c0af1f3b4e.png)



