### PR TITLE
Updates to pyufp to 1.4.0 and remove e- from thumbnail URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # // Changelog
 
+## 0.11.2
+
+* `FIX`: Setting up camera entities will no longer error if a camera does not have a channel. Will now result in log and continue
+
+* `FIX`: Unadopted entities are ignored (fixes #420)
+
+* `FIX`: Event thumbnails now return instantly using newer endpoint from UniFi Protect. They appear to come back as a camera snapshot until after the events ends, but they should always return an image now.
+
 ## 0.11.1
 
 ### Deprecations

--- a/custom_components/unifiprotect/binary_sensor.py
+++ b/custom_components/unifiprotect/binary_sensor.py
@@ -427,13 +427,11 @@ class ProtectAccessTokenBinarySensor(ProtectDeviceBinarySensor, AccessTokenMixin
             attrs[ATTR_EVENT_OBJECT] = self._event.smart_detect_types[0].value
 
         if len(self.access_tokens) > 0:
-            # thumbnail_id is never updated via WS, but it is always e-{event.id}
             params = urlencode(
                 {"entity_id": self.entity_id, "token": self.access_tokens[-1]}
             )
             attrs[ATTR_EVENT_THUMB] = (
-                ThumbnailProxyView.url.format(event_id=f"e-{self._event.id}")
-                + f"?{params}"
+                ThumbnailProxyView.url.format(event_id=self._event.id) + f"?{params}"
             )
 
         return attrs

--- a/custom_components/unifiprotect/data.py
+++ b/custom_components/unifiprotect/data.py
@@ -108,8 +108,13 @@ class ProtectData:
                     "Doorbell settings updated. Restart Home Assistant to update Viewport select options"
                 )
         # trigger updates for camera that the event references
-        elif isinstance(message.new_obj, Event) and message.new_obj.camera is not None:
-            self.async_signal_device_id_update(message.new_obj.camera.id)
+        elif isinstance(message.new_obj, Event):
+            if message.new_obj.camera is not None:
+                self.async_signal_device_id_update(message.new_obj.camera.id)
+            elif message.new_obj.light is not None:
+                self.async_signal_device_id_update(message.new_obj.light.id)
+            elif message.new_obj.sensor is not None:
+                self.async_signal_device_id_update(message.new_obj.sensor.id)
         # trigger update for all viewports when a liveview updates
         elif len(self.api.bootstrap.viewers) > 0 and isinstance(
             message.new_obj, Liveview

--- a/custom_components/unifiprotect/manifest.json
+++ b/custom_components/unifiprotect/manifest.json
@@ -5,12 +5,12 @@
   "issue_tracker": "https://github.com/briis/unifiprotect/issues",
   "config_flow": true,
   "requirements": [
-    "pyunifiprotect==1.3.4"
+    "pyunifiprotect==1.4.0"
   ],
   "dependencies": [
     "http"
   ],
-  "version": "0.10.0",
+  "version": "0.11.2",
   "codeowners": [
     "@briis",
     "@AngellusMortis",

--- a/custom_components/unifiprotect/sensor.py
+++ b/custom_components/unifiprotect/sensor.py
@@ -515,13 +515,11 @@ class ProtectAccessTokenSensor(ProtectDeviceSensor, AccessTokenMixin):
         thumb_url: str | None = None
         if len(self.access_tokens) > 0:
             assert self.device_info is not None
-            # thumbnail_id is never updated via WS, but it is always e-{event.id}
             params = urlencode(
                 {"entity_id": self.entity_id, "token": self.access_tokens[-1]}
             )
             thumb_url = (
-                ThumbnailProxyView.url.format(event_id=f"e-{self._event.id}")
-                + f"?{params}"
+                ThumbnailProxyView.url.format(event_id=self._event.id) + f"?{params}"
             )
 
         return {


### PR DESCRIPTION
* `FIX`: Unadopted entities are ignored (fixes #420)

* `FIX`: Event thumbnails now return instantly using newer endpoint from UniFi Protect. They appear to come back as a camera snapshot until after the events ends, but they should always return an image now.