### PR TITLE
Adds 2022.2 upgrade warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Install Linting Dependencies
         run: |
           git clone --depth=1 -b dev https://github.com/home-assistant/core.git hass
+          rm -rf ./hass/homeassistant/components/unifiprotect
           ln -s $GITHUB_WORKSPACE/custom_components/unifiprotect ./hass/homeassistant/components/unifiprotect
 
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # // UniFi Protect for Home Assistant
 
+-----
+## ⚠️ ⚠️ WARNING ABOUT Home Assistant v2022.2
+The `unifiprotect` integration will be in Home Assistant core v2022.2. If you are running **0.10.x or older** of the HACS integration, **do not install v2022.2.x of Home Assistant core**.
+
+If you are running 0.11.x or the 0.12.0-beta, you should be safe to delete the HACS version as part of your upgrade. The 0.11.x branch is designed to be compatible with the 0.12.0-beta and the HA core version. The latest version of 0.12.0-beta will be the version of `unifiprotect` in HA core in v2022.0.
+
+After v2022.2 comes out, this repo will be **deprecated** in favor of the Home Assistant core version.
+
+-----
+
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/briis/unifiprotect?style=flat-square) [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=flat-square)](https://github.com/custom-components/hacs) [![](https://img.shields.io/badge/COMMUNITY-FORUM-success?style=flat-square)](https://community.home-assistant.io/t/custom-component-unifi-protect/158041)
 
 The UniFi Protect Integration adds support for retrieving Camera feeds and Sensor data from a UniFi Protect installation on either an Ubiquiti CloudKey+, Ubiquiti UniFi Dream Machine Pro or UniFi Protect Network Video Recorder.

--- a/custom_components/unifiprotect/entity.py
+++ b/custom_components/unifiprotect/entity.py
@@ -237,7 +237,7 @@ class AccessTokenMixin(Entity):
         return self.data.async_get_or_create_access_tokens(self.entity_id)
 
     @callback
-    def _async_update_and_write_token(self):
+    def _async_update_and_write_token(self) -> None:
         _LOGGER.debug("Updating access tokens for %s", self.entity_id)
         self.async_update_token()
         self.async_write_ha_state()
@@ -250,7 +250,7 @@ class AccessTokenMixin(Entity):
         )
 
     @callback
-    def _trigger_update_tokens(self, *args, **kwargs):
+    def _trigger_update_tokens(self, *args: Any, **kwargs: Any) -> None:
         assert isinstance(self, ProtectDeviceEntity)
         async_dispatcher_send(
             self.hass,

--- a/custom_components/unifiprotect/services.py
+++ b/custom_components/unifiprotect/services.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -76,9 +77,9 @@ def _async_get_protect_from_call(
 async def _async_call_nvr(
     instances: list[tuple[dr.DeviceEntry, ProtectApiClient]],
     method: str,
-    *args,
-    **kwargs,
-):
+    *args: Any,
+    **kwargs: Any,
+) -> None:
     try:
         await asyncio.gather(
             *(getattr(i.bootstrap.nvr, method)(*args, **kwargs) for _, i in instances)


### PR DESCRIPTION
Now that the first HA core PR has been merged and `unifiprotect` will officially be in 2022.2, I figured it is a good idea to add this warning for users. I will go through and add it to all of the recent releases/tags (probably back to 0.9.x versions) as well so hopefully no one will miss the noticed.