### PR TITLE
Backports various fixes from core merge

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update \
     && sudo apt install -y libpcap-dev ffmpeg vim curl jq libturbojpeg0 \
     && mkdir -p /opt \
     && cd /opt \
-    && git clone --depth=1 -b dev https://github.com/home-assistant/core.git hass \
+    && git clone --depth=1 -b 2021.12.7 https://github.com/home-assistant/core.git hass \
     && python3 -m pip --disable-pip-version-check install --upgrade ./hass \
     && python3 -m pip install pyunifiprotect mypy black isort pyupgrade pylint pylint_strict_informational \
     && ln -s /workspaces/unifiprotect/custom_components/unifiprotect /opt/hass/homeassistant/components/unifiprotect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # // Changelog
 
+## 0.12.0-beta2
+
+The 0.12.0-beta is designed to be a "beta only" release. There will not be a stable release for it. It is designed to test the final changes needed to merge the unifiprotect into Home Assistant core.
+
+Backports fixes from Home Assistant core merge process:
+
+* `FIX`: Improves relibility of entities when UniFi Protect goes offline and/or a device goes offline. Everything recovery seemlessly when UniFi Protect upgrades or firmware updates are applied (fixes https://github.com/briis/unifiprotect/issues/432).
+
+* `FIX`: Improves relibility of `media_player` entities so they should report state better and be able to play longer audio clips.
+
+* `FIX`: Fixes stopping in progress audio for `media_player` entities.
+
+* `FIX`: Allows DNS hosts in addition to IP addresses (fixes https://github.com/briis/unifiprotect/issues/431).
+
+* `FIX`: Fixes selection of default camera entity for when it is not the High Quality channel.
+
 ## 0.12.0-beta1
 
 The 0.12.0-beta is designed to be a "beta only" release. There will not be a stable release for it. It is designed to test the final changes needed to merge the unifiprotect into Home Assistant core.

--- a/custom_components/unifiprotect/button.py
+++ b/custom_components/unifiprotect/button.py
@@ -2,12 +2,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable, Sequence
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import Entity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
 
 from .const import DEVICES_THAT_ADOPT, DOMAIN
@@ -20,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: Callable[[Sequence[Entity]], None],
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Discover devices on a UniFi Protect NVR."""
     data: ProtectData = hass.data[DOMAIN][entry.entry_id]
@@ -43,14 +42,13 @@ class ProtectButton(ProtectDeviceEntity, ButtonEntity):
         self,
         data: ProtectData,
         device: ProtectAdoptableDeviceModel,
-    ):
+    ) -> None:
         """Initialize an UniFi camera."""
         super().__init__(data, device)
         self._attr_name = f"{self.device.name} Reboot Device"
         self._attr_entity_registry_enabled_default = False
         self._attr_device_class = ButtonDeviceClass.RESTART
 
-    @callback
     async def async_press(self) -> None:
         """Press the button."""
 

--- a/custom_components/unifiprotect/const.py
+++ b/custom_components/unifiprotect/const.py
@@ -53,6 +53,7 @@ DEVICES_FOR_SUBSCRIBE = DEVICES_WITH_ENTITIES | {ModelType.EVENT}
 EVENT_UPDATE_TOKENS = "unifiprotect_update_tokens"
 
 MIN_REQUIRED_PROTECT_V = Version("1.20.0")
+OUTDATED_LOG_MESSAGE = "You are running v%s of UniFi Protect. Minimum required version is v%s. Please upgrade UniFi Protect and then retry"
 
 SERVICE_PROFILE_WS = "profile_ws_messages"
 SERVICE_ADD_DOORBELL_TEXT = "add_doorbell_text"

--- a/custom_components/unifiprotect/entity.py
+++ b/custom_components/unifiprotect/entity.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.entity import DeviceInfo, Entity, EntityDescription
 from pyunifiprotect.data.base import ProtectAdoptableDeviceModel
 from pyunifiprotect.data.devices import Camera, Light, Sensor, Viewer
 from pyunifiprotect.data.nvr import NVR
-from pyunifiprotect.data.types import ModelType
+from pyunifiprotect.data.types import ModelType, StateType
 
 from .const import DEFAULT_ATTRIBUTION, DEFAULT_BRAND, DOMAIN, EVENT_UPDATE_TOKENS
 from .data import ProtectData
@@ -172,7 +172,7 @@ class ProtectDeviceEntity(Entity):
             self.device = devices[self.device.id]
 
         self._attr_available = (
-            self.data.last_update_success and self.device.is_connected
+            self.data.last_update_success and self.device.state == StateType.CONNECTED
         )
         self._extra_state_attributes = self._async_update_extra_attrs_from_protect()
 

--- a/custom_components/unifiprotect/manifest.json
+++ b/custom_components/unifiprotect/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/briis/unifiprotect/issues",
   "config_flow": true,
   "requirements": [
-    "pyunifiprotect==1.4.4"
+    "pyunifiprotect==1.4.7"
   ],
   "dependencies": [
     "http"

--- a/custom_components/unifiprotect/media_player.py
+++ b/custom_components/unifiprotect/media_player.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Sequence
+from typing import Any
 
 from homeassistant.components.media_player import (
     DEVICE_CLASS_SPEAKER,
@@ -12,7 +12,6 @@ from homeassistant.components.media_player import (
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SUPPORT_PLAY_MEDIA,
-    SUPPORT_SELECT_SOURCE,
     SUPPORT_STOP,
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
@@ -20,8 +19,10 @@ from homeassistant.components.media_player.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_IDLE, STATE_PLAYING
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import Entity
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pyunifiprotect.data import Camera
+from pyunifiprotect.exceptions import StreamError
 
 from .const import DOMAIN
 from .data import ProtectData
@@ -33,7 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: Callable[[Sequence[Entity]], None],
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Discover cameras with speakers on a UniFi Protect NVR."""
     data: ProtectData = hass.data[DOMAIN][entry.entry_id]
@@ -68,11 +69,7 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
 
         self._attr_name = f"{self.device.name} Speaker"
         self._attr_supported_features = (
-            SUPPORT_PLAY_MEDIA
-            | SUPPORT_VOLUME_SET
-            | SUPPORT_VOLUME_STEP
-            | SUPPORT_STOP
-            | SUPPORT_SELECT_SOURCE
+            SUPPORT_PLAY_MEDIA | SUPPORT_VOLUME_SET | SUPPORT_VOLUME_STEP | SUPPORT_STOP
         )
         self._attr_media_content_type = MEDIA_TYPE_MUSIC
 
@@ -89,14 +86,13 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
         else:
             self._attr_state = STATE_IDLE
 
-    @callback
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
 
         volume_int = int(volume * 100)
         await self.device.set_speaker_volume(volume_int)
 
-    def media_stop(self) -> None:
+    async def async_media_stop(self) -> None:
         """Send stop command."""
 
         if (
@@ -104,7 +100,8 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
             and self.device.talkback_stream.is_running
         ):
             _LOGGER.debug("Stopping playback for %s Speaker", self.device.name)
-            self.device.talkback_stream.stop()
+            await self.device.stop_audio()
+            self._async_updated_event()
 
     async def async_play_media(
         self, media_type: str, media_id: str, **kwargs: Any
@@ -112,12 +109,18 @@ class ProtectMediaPlayer(ProtectDeviceEntity, MediaPlayerEntity):
         """Play a piece of media."""
 
         if media_type != MEDIA_TYPE_MUSIC:
-            return
+            raise ValueError("Only music media type is supported")
 
         _LOGGER.debug("Playing Media %s for %s Speaker", media_id, self.device.name)
-        self.media_stop()
-        self._attr_state = STATE_PLAYING
+        await self.async_media_stop()
         try:
-            await self.device.play_audio(media_id)
-        finally:
+            await self.device.play_audio(media_id, blocking=False)
+        except StreamError as err:
+            raise HomeAssistantError from err
+        else:
+            # update state after starting player
             self._async_updated_event()
+            # wait until player finishes to update state again
+            await self.device.wait_until_audio_completes()
+
+        self._async_updated_event()


### PR DESCRIPTION
There are no new code changes in this PR. Just copy/pastes from the HA core version. Not everything was ported due to risk bugs with the changes to the base entity class. Will likely make another PR after everything else is ported. Just wanted to get some of the major fixes here in. 

Backports fixes from Home Assistant core merge process:

* `FIX`: Improves relibility of entities when UniFi Protect goes offline and/or a device goes offline. Everything recovery seemlessly when UniFi Protect upgrades or firmware updates are applied (fixes https://github.com/briis/unifiprotect/issues/432).

* `FIX`: Improves relibility of `media_player` entities so they should report state better and be able to play longer audio clips.

* `FIX`: Fixes stopping in progress audio for `media_player` entities.

* `FIX`: Allows DNS hosts in addition to IP addresses (fixes https://github.com/briis/unifiprotect/issues/431).

* `FIX`: Fixes selection of default camera entity for when it is not the High Quality channel.