### PR TITLE
Adds generate_data service

### DIFF
--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -48,10 +48,10 @@ from .const import (
 from .data import ProtectData
 from .services import (
     add_doorbell_text,
-    generate_data,
     profile_ws,
     remove_doorbell_text,
     set_default_doorbell_text,
+    take_sample,
 )
 from .views import ThumbnailProxyView
 
@@ -234,7 +234,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         (SERVICE_PROFILE_WS, functools.partial(profile_ws, hass), PROFILE_WS_SCHEMA),
         (
             SERVICE_GENERATE_DATA,
-            functools.partial(generate_data, hass),
+            functools.partial(take_sample, hass),
             GENERATE_DATA_SCHEMA,
         ),
     ]

--- a/custom_components/unifiprotect/__init__.py
+++ b/custom_components/unifiprotect/__init__.py
@@ -35,10 +35,12 @@ from .const import (
     DEVICES_THAT_ADOPT,
     DOMAIN,
     DOORBELL_TEXT_SCHEMA,
+    GENERATE_DATA_SCHEMA,
     MIN_REQUIRED_PROTECT_V,
     PLATFORMS,
     PROFILE_WS_SCHEMA,
     SERVICE_ADD_DOORBELL_TEXT,
+    SERVICE_GENERATE_DATA,
     SERVICE_PROFILE_WS,
     SERVICE_REMOVE_DOORBELL_TEXT,
     SERVICE_SET_DEFAULT_DOORBELL_TEXT,
@@ -46,6 +48,7 @@ from .const import (
 from .data import ProtectData
 from .services import (
     add_doorbell_text,
+    generate_data,
     profile_ws,
     remove_doorbell_text,
     set_default_doorbell_text,
@@ -229,6 +232,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             DOORBELL_TEXT_SCHEMA,
         ),
         (SERVICE_PROFILE_WS, functools.partial(profile_ws, hass), PROFILE_WS_SCHEMA),
+        (
+            SERVICE_GENERATE_DATA,
+            functools.partial(generate_data, hass),
+            GENERATE_DATA_SCHEMA,
+        ),
     ]
     for name, method, schema in services:
         if hass.services.has_service(DOMAIN, name):

--- a/custom_components/unifiprotect/const.py
+++ b/custom_components/unifiprotect/const.py
@@ -23,7 +23,7 @@ CONF_DOORBELL_TEXT = "doorbell_text"
 CONF_DISABLE_RTSP = "disable_rtsp"
 CONF_MESSAGE = "message"
 CONF_DURATION = "duration"
-CONF_ACTUAL = "actual"
+CONF_ANONYMIZE = "anonymize"
 CONF_ALL_UPDATES = "all_updates"
 CONF_OVERRIDE_CHOST = "override_connection_host"
 
@@ -56,7 +56,7 @@ EVENT_UPDATE_TOKENS = "unifiprotect_update_tokens"
 MIN_REQUIRED_PROTECT_V = Version("1.20.0")
 OUTDATED_LOG_MESSAGE = "You are running v%s of UniFi Protect. Minimum required version is v%s. Please upgrade UniFi Protect and then retry"
 
-SERVICE_GENERATE_DATA = "generate_data"
+SERVICE_GENERATE_DATA = "take_sample"
 SERVICE_PROFILE_WS = "profile_ws_messages"
 SERVICE_ADD_DOORBELL_TEXT = "add_doorbell_text"
 SERVICE_REMOVE_DOORBELL_TEXT = "remove_doorbell_text"
@@ -92,7 +92,7 @@ GENERATE_DATA_SCHEMA = vol.All(
         {
             **cv.ENTITY_SERVICE_FIELDS,
             vol.Required(CONF_DURATION): vol.Coerce(int),
-            vol.Required(CONF_ACTUAL): vol.Coerce(bool),
+            vol.Required(CONF_ANONYMIZE): vol.Coerce(bool),
         },
     ),
     cv.has_at_least_one_key(CONF_DEVICE_ID),

--- a/custom_components/unifiprotect/const.py
+++ b/custom_components/unifiprotect/const.py
@@ -23,6 +23,7 @@ CONF_DOORBELL_TEXT = "doorbell_text"
 CONF_DISABLE_RTSP = "disable_rtsp"
 CONF_MESSAGE = "message"
 CONF_DURATION = "duration"
+CONF_ACTUAL = "actual"
 CONF_ALL_UPDATES = "all_updates"
 CONF_OVERRIDE_CHOST = "override_connection_host"
 
@@ -55,6 +56,7 @@ EVENT_UPDATE_TOKENS = "unifiprotect_update_tokens"
 MIN_REQUIRED_PROTECT_V = Version("1.20.0")
 OUTDATED_LOG_MESSAGE = "You are running v%s of UniFi Protect. Minimum required version is v%s. Please upgrade UniFi Protect and then retry"
 
+SERVICE_GENERATE_DATA = "generate_data"
 SERVICE_PROFILE_WS = "profile_ws_messages"
 SERVICE_ADD_DOORBELL_TEXT = "add_doorbell_text"
 SERVICE_REMOVE_DOORBELL_TEXT = "remove_doorbell_text"
@@ -80,6 +82,17 @@ DOORBELL_TEXT_SCHEMA = vol.All(
         {
             **cv.ENTITY_SERVICE_FIELDS,
             vol.Required(CONF_MESSAGE): cv.string,
+        },
+    ),
+    cv.has_at_least_one_key(CONF_DEVICE_ID),
+)
+
+GENERATE_DATA_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            **cv.ENTITY_SERVICE_FIELDS,
+            vol.Required(CONF_DURATION): vol.Coerce(int),
+            vol.Required(CONF_ACTUAL): vol.Coerce(bool),
         },
     ),
     cv.has_at_least_one_key(CONF_DEVICE_ID),

--- a/custom_components/unifiprotect/services.py
+++ b/custom_components/unifiprotect/services.py
@@ -12,9 +12,9 @@ from pydantic import ValidationError
 from pyunifiprotect.api import ProtectApiClient
 from pyunifiprotect.exceptions import BadRequest
 
-from .const import CONF_DURATION, CONF_MESSAGE, DOMAIN
+from .const import CONF_ACTUAL, CONF_DURATION, CONF_MESSAGE, DOMAIN
 from .data import ProtectData
-from .utils import profile_ws_messages
+from .utils import generate_sample_data, profile_ws_messages
 
 
 def _async_all_ufp_instances(hass: HomeAssistant) -> list[ProtectApiClient]:
@@ -116,6 +116,19 @@ async def profile_ws(hass: HomeAssistant, call: ServiceCall) -> None:
     await asyncio.gather(
         *(
             profile_ws_messages(hass, i, duration, device_entry)
+            for device_entry, i in instances
+        )
+    )
+
+
+async def generate_data(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Generate sample data."""
+    duration: int = call.data[CONF_DURATION]
+    actual_data: bool = call.data[CONF_ACTUAL]
+    instances = _async_get_protect_from_call(hass, call)
+    await asyncio.gather(
+        *(
+            generate_sample_data(hass, i, duration, not actual_data, device_entry)
             for device_entry, i in instances
         )
     )

--- a/custom_components/unifiprotect/services.py
+++ b/custom_components/unifiprotect/services.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 from pyunifiprotect.api import ProtectApiClient
 from pyunifiprotect.exceptions import BadRequest
 
-from .const import CONF_ACTUAL, CONF_DURATION, CONF_MESSAGE, DOMAIN
+from .const import CONF_ANONYMIZE, CONF_DURATION, CONF_MESSAGE, DOMAIN
 from .data import ProtectData
 from .utils import generate_sample_data, profile_ws_messages
 
@@ -121,14 +121,14 @@ async def profile_ws(hass: HomeAssistant, call: ServiceCall) -> None:
     )
 
 
-async def generate_data(hass: HomeAssistant, call: ServiceCall) -> None:
+async def take_sample(hass: HomeAssistant, call: ServiceCall) -> None:
     """Generate sample data."""
     duration: int = call.data[CONF_DURATION]
-    actual_data: bool = call.data[CONF_ACTUAL]
+    anonymize: bool = call.data[CONF_ANONYMIZE]
     instances = _async_get_protect_from_call(hass, call)
     await asyncio.gather(
         *(
-            generate_sample_data(hass, i, duration, not actual_data, device_entry)
+            generate_sample_data(hass, i, duration, anonymize, device_entry)
             for device_entry, i in instances
         )
     )

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -21,7 +21,7 @@ take_sample:
           step: 10
           unit_of_measurement: seconds
     anonymize:
-      name:  Anonymize Data
+      name: Anonymize Data
       description: Data is anonymized by default to make safe for distribution.
       default: true
       required: true

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -1,3 +1,32 @@
+generate_data:
+  name: Generate UniFi Protect Sample Data
+  description: Generates Sample Data from a given UniFi Protect instance. Useful for debugging or reporting issues.
+  fields:
+    device_id:
+      name: UniFi Protect NVR
+      description: Main NVR for the UniFi Protect instance you would like to target.
+      required: true
+      selector:
+        device:
+          integration: unifiprotect
+    duration:
+      name: Websocket Capture Time
+      description: How long to capture Websocket messages for.
+      default: 30
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 600
+          step: 10
+          unit_of_measurement: seconds
+    actual:
+      name:  Actual Data?
+      description: Generate actual data from UniFi Protect. Otherwise data is automatically anonymized to make safe for distribution.
+      default: false
+      required: true
+      selector:
+        boolean:
 profile_ws_messages:
   name: Profile UniFi Protect WS Messages
   description: Profiles UniFi Protect Web Socket messages and prints out summary afterwards.

--- a/custom_components/unifiprotect/services.yaml
+++ b/custom_components/unifiprotect/services.yaml
@@ -1,5 +1,5 @@
-generate_data:
-  name: Generate UniFi Protect Sample Data
+take_sample:
+  name: Sample UniFi Protect Data
   description: Generates Sample Data from a given UniFi Protect instance. Useful for debugging or reporting issues.
   fields:
     device_id:
@@ -20,10 +20,10 @@ generate_data:
           max: 600
           step: 10
           unit_of_measurement: seconds
-    actual:
-      name:  Actual Data?
-      description: Generate actual data from UniFi Protect. Otherwise data is automatically anonymized to make safe for distribution.
-      default: false
+    anonymize:
+      name:  Anonymize Data
+      description: Data is anonymized by default to make safe for distribution.
+      default: true
       required: true
       selector:
         boolean:

--- a/custom_components/unifiprotect/utils.py
+++ b/custom_components/unifiprotect/utils.py
@@ -6,6 +6,8 @@ from enum import Enum
 from io import StringIO
 import json
 import logging
+from pathlib import Path
+import shutil
 import time
 from typing import Any
 
@@ -13,6 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntry
 from pyunifiprotect.api import ProtectApiClient
+from pyunifiprotect.test_util import SampleDataGenerator
 from pyunifiprotect.utils import print_ws_stat_summary
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,7 +66,7 @@ async def profile_ws_messages(
     protect.bootstrap.capture_ws_stats = False
 
     json_data = [s.__dict__ for s in protect.bootstrap.ws_stats]
-    out_path = hass.config.path(f"ws_profile.{start_time}.json")
+    out_path = hass.config.path(f"ufp_ws_profile.{start_time}.json")
     with open(out_path, "w", encoding="utf8") as outfile:
         json.dump(json_data, outfile, indent=4)
 
@@ -75,5 +78,45 @@ async def profile_ws_messages(
     hass.components.persistent_notification.async_create(
         f"Wrote raw stats to {out_path}\n\n```\n{stats_buffer.getvalue()}\n```",
         title=f"{name}: WS Profile Completed",
+        notification_id=message_id,
+    )
+
+
+async def generate_sample_data(
+    hass: HomeAssistant,
+    protect: ProtectApiClient,
+    seconds: int,
+    anonymize: bool,
+    device_entry: DeviceEntry,
+) -> None:
+    """Generate sample data from Protect intance."""
+
+    start_time = time.time()
+    name = device_entry.name_by_user or device_entry.name or device_entry.id
+    folder = f"ufp_sample.{start_time}"
+    out_path = hass.config.path(folder)
+    nvr_id = name.replace(" ", "_").lower()
+    message_id = f"ufp_ws_profiler_{nvr_id}_{start_time}"
+    hass.components.persistent_notification.async_create(
+        "The sample data generation has started. This notification will be updated when it is complete.",
+        title=f"{name}: Sample Data Generation Started",
+        notification_id=message_id,
+    )
+
+    _LOGGER.info(
+        "%s: Start Sample Data for %ss (anonymize: %s)", name, seconds, anonymize
+    )
+    await SampleDataGenerator(
+        protect, Path(out_path), anonymize, seconds
+    ).async_generate(close_session=False)
+    shutil.make_archive(out_path, "zip", out_path)
+    shutil.rmtree(out_path)
+    out_path = f"{out_path}.zip"
+
+    _LOGGER.info("%s: Complete Sample Data:\n%s", name, out_path)
+
+    hass.components.persistent_notification.async_create(
+        f"Wrote sample data to {out_path}",
+        title=f"{name}: Sample Data Generation Completed",
         notification_id=message_id,
     )


### PR DESCRIPTION
One last debug service to add. It was originally only a utility for generating data for tests, but it can be something we integrate into issue reporting

There is actually a bug in the anonymization of data, so right now only "actual" works. I would also like to make it so the log messages actually log instead of print to console if not ran in "CLI mode", but both things are upstream in the in `pyunifiprotect` so does not affect this PR or any code in it.