### PR TITLE
Test that the trigger object matches filter defined by objects input

### DIFF
--- a/blueprints/automation/unifiprotect/push_notification_smart_event.yaml
+++ b/blueprints/automation/unifiprotect/push_notification_smart_event.yaml
@@ -265,7 +265,7 @@ trigger:
 
 condition:
   - "{{ not input_presence_filter or not is_state(input_presence_filter, 'home') }}"
-  - "{{ trigger_object != 'none' and trigger_object != 'unavailable' }}"
+  - "{{ trigger_object != 'none' and trigger_object != 'unavailable' and trigger_object in smart_detect_objs }}"
 
 action:
   - choose:


### PR DESCRIPTION
The blueprint defines an 'objects' input as a filter of detection types (person or vehicle), but it is currently ignore. The automation will trigger regardless of what the filter is set to. This PR adds a test to ensure the trigger event type matches the user defined filter.